### PR TITLE
Improve testing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,170 @@
+# Copyright 2019 ETH Zurich and University of Bologna
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# variables:
+#  PULP_RISCV_GCC_TOOLCHAIN: your-compiler-path
+
+before_script:
+  - pwd
+
+# after_script:
+#   - echo "stage finished"
+
+stages:
+  - fetch
+  - build
+  - test
+
+fetch_tests:
+  stage: fetch
+  script:
+    - echo "Fetching tests"
+    - make test-checkout-gitlab
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA"
+    paths:
+      - tests/*
+
+fetch_ips:
+  stage: fetch
+  script:
+    - echo "Fetching IPs"
+    - make checkout
+    - echo "Fetching VIPs"
+    - ./rtl/vip/get-vips.sh --yes --gitlab
+    - echo "Generate scripts with DPI and VIP support"
+    - ./generate-scripts --rt-dpi --i2c-vip --flash-vip --i2s-vip
+
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA"
+    paths:
+      - ips/*
+      - sim/*
+      - ipstools/*
+      - rtl/vip/*
+      - .cached_ipdb.json
+
+# This jobs result is too large to produce an artifact
+# fetch_sdk:
+#   stage: fetch
+#   script:
+#     - echo "Fetching SDK from releases and setting up paths"
+#     - make sdk-gitlab
+#   artifacts:
+#     paths:
+#       - pkg/
+#       - env/
+
+build_rtl:
+  stage: build
+  before_script:
+  script:
+    - echo "Compiling RTL model and DPI libraries"
+    - make build
+    - echo "Installing scripts"
+    - make install
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA"
+    paths:
+      - tests/*
+      - ips/*
+      - sim/*
+      - ipstools/*
+#      - install/* # we have to rebuild in test stage because rtl libraries are
+                   # not relocatable (hardcoded paths)
+      - rtl/tb/remote_bitbang/* # we want to reuse bitbang lib
+#      - pkg/* # sdk is too large
+
+test_sw:
+  stage: test
+  before_script:
+    - echo "Fetching SDK from releases and setting up paths"
+    - make sdk-gitlab
+    - echo "Compiling RTL model and DPI libraries"
+    - make build
+    - echo "Installing scripts"
+    - make install
+  script:
+    - echo "Running software tests"
+    - make test-gitlab
+    - echo "Generating junit test results"
+    - /usr/sepp/bin/pip3.4 install --user junit2html
+    - /usr/sepp/bin/python3.4 -m junit2htmlreport tests/junit-reports/TEST-*.xml
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA"
+    paths:
+      - tests/junit-reports/TEST-*.html
+      - tests/junit-reports/TEST-*.xml
+    reports:
+      junit: tests/junit-reports/TEST-*.xml
+
+# test_sw_build_sdk:
+#   stage: test
+#   before_script:
+#     - echo "Compiling RTL model and DPI libraries"
+#     - make build
+#     - echo "Installing scripts" # don't call this, breaks build
+#     - make install
+#     - echo "Building SDK"
+#     - make sdk
+#   script:
+#     - echo "Running software tests with built SDK"
+#     - make test-gitlab2
+#     - echo "Generating junit test results"
+#     - /usr/sepp/bin/pip3.4 install --user junit2html
+#     - /usr/sepp/bin/python3.4 -m junit2htmlreport tests/junit-reports/TEST-*.xml
+#   artifacts:
+#     paths:
+#       - tests/junit-reports/TEST-*.html
+#       - tests/junit-reports/TEST-*.xml
+#     reports:
+#       junit: tests/junit-reports/TEST-*.xml
+
+test_dm:
+  stage: test
+  before_script:
+  script:
+    - echo "(Re)generating scripts with DPI disabled"
+    - ./generate-scripts
+    - echo "Setting up vsim path"
+    - source setup/vsim.sh
+    - echo "Running debug module testbench"
+    - cd sim/ && make lib build opt simc VSIM_FLAGS=-gENABLE_DM_TESTS=1
+
+fpga_synth:
+  stage: test
+  before_script:
+  script:
+    - echo "(Re)generating scripts" # because paths might have changed
+    - ./generate-scripts
+    - echo "Starting synthesis with vivado"
+    - cd fpga/ && make genesys2 VIVADO='vivado-2019.1.1 vivado'
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA"
+    paths:
+      - fpga/pulpissimo_genesys2.bit
+      - fpga/pulpissimo_genesys2.bin
+      - fpga/*.jou
+      - fpga/*.log
+      - fpga/*.str
+      - fpga/pulpissimo-genesys2/reports
+      - fpga/pulpissimo-genesys2/rtl
+      - fpga/pulpissimo-genesys2/tcl
+      - fpga/pulpissimo-genesys2/pulpissimo_genesys2.xpr
+      - fpga/pulpissimo-genesys2/fpga-settings.mk
+      - fpga/pulpissimo-genesys2/*.log
+      - fpga/pulpissimo-genesys2/*.cfg
+      - fpga/pulpissimo-genesys2/*.gdb
+      - fpga/pulpissimo-genesys2/*.jou
+      - fpga/pulpissimo-genesys2/*.log

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# variables:
-#  PULP_RISCV_GCC_TOOLCHAIN: your-compiler-path
+
 
 before_script:
   - pwd
@@ -86,6 +85,7 @@ build_rtl:
       - rtl/tb/remote_bitbang/* # we want to reuse bitbang lib
 #      - pkg/* # sdk is too large
 
+# Use sdk-releases to run all tests
 test_sw:
   stage: test
   before_script:
@@ -109,7 +109,10 @@ test_sw:
     reports:
       junit: tests/junit-reports/TEST-*.xml
 
+# Built SDK with the `make sdk` target and run all tests
 # test_sw_build_sdk:
+#   variables:
+#     PULP_RISCV_GCC_TOOLCHAIN: your-compiler-path
 #   stage: test
 #   before_script:
 #     - echo "Compiling RTL model and DPI libraries"

--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,7 @@ test:
 # GITLAB CI
 # continuous integration on gitlab
 sdk-gitlab:
-	sdk-releases/get-sdk-2019.11.02-CentOS_7.py; \
-	cd pkg && patch -p1 < ../sdk-releases/pulp-sdk-2019.11.02-junit.patch
+	sdk-releases/get-sdk-2019.11.03-CentOS_7.py; \
 
 # the gitlab runner needs a special configuration to be able to access the
 # dependent git repositories
@@ -97,9 +96,9 @@ test-checkout-gitlab:
 
 # test with sdk release
 test-gitlab:
-	source env/env-sdk-2019.11.02.sh; \
-	source pkg/sdk/2019.11.02/configs/pulp.sh; \
-	source pkg/sdk/2019.11.02/configs/platform-rtl.sh; \
+	source env/env-sdk-2019.11.03.sh; \
+	source pkg/sdk/2019.11.03/configs/pulp.sh; \
+	source pkg/sdk/2019.11.03/configs/platform-rtl.sh; \
 	cd tests && plptest --threads 16 --stdout
 
 # test with built sdk

--- a/generate-scripts
+++ b/generate-scripts
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+
 # Francesco Conti <f.conti@unibo.it>
 #
 # Copyright (C) 2016-2018 ETH Zurich, University of Bologna.
@@ -6,6 +7,27 @@
 
 from ipstools_cfg import *
 import fileinput
+import argparse
+
+parser = argparse.ArgumentParser(
+    prog='PULP generate script',
+    description="""generate build/compile/synthesis scripts for PULPissimo""")
+
+parser.add_argument('--rt-dpi', action='store_true',
+                    help="""Use the PULP Runtime DPI to emulate peripherals""")
+parser.add_argument('--i2c-vip', action='store_true',
+                    help="""Use the i2c model (24FC1025).
+                    Needs to be installed.""")
+parser.add_argument('--flash-vip', action='store_true',
+                    help="""Use the flash model (S25FS256).
+                    Needs to be installed.""")
+parser.add_argument('--i2s-vip', action='store_true',
+                    help="""Use the i2s model (24FC1025).
+                    Needs to be installed.""")
+parser.add_argument('--verbose', action='store_true',
+                    help='Show more information about commands')
+
+args = parser.parse_args()
 
 execute("mkdir -p sim/vcompile/ips")
 execute("rm -rf sim/vcompile/ips/*")
@@ -24,7 +46,24 @@ execute("mkdir -p sim/ncompile/tb")
 execute("rm -rf sim/ncompile/tb/*")
 
 # creates an IPApproX database
-ipdb = ipstools.IPDatabase(rtl_dir='rtl', ips_dir='ips', vsim_dir='sim', load_cache=True)
+ipdb = ipstools.IPDatabase(rtl_dir='rtl', ips_dir='ips', vsim_dir='sim',
+                           load_cache=True, verbose=args.verbose)
+
+# setting defines
+if args.rt_dpi:
+    ipdb.rtl_dic['tb'].sub_ips['tb'].defines = ['USE_DPI']
+
+# handling VIPs
+# assume by default that the user didn't install the proprietary VIPs so we
+# remove the IP keys
+if not args.i2c_vip:
+    del (ipdb.rtl_dic['vip'].sub_ips['24FC1025_model'])
+
+if not args.flash_vip:
+    del (ipdb.rtl_dic['vip'].sub_ips['S25FS256_model'])
+
+if not args.i2s_vip:
+    del (ipdb.rtl_dic['vip'].sub_ips['i2s_model'])
 
 # generate ModelSim/QuestaSim compilation scripts
 ipdb.export_make(script_path="sim/vcompile/ips")

--- a/rtl/vip/.gitignore
+++ b/rtl/vip/.gitignore
@@ -1,0 +1,4 @@
+i2c_eeprom/
+spi_flash/
+i2s/
+vip-proprietary/

--- a/rtl/vip/get-vips.sh
+++ b/rtl/vip/get-vips.sh
@@ -1,0 +1,46 @@
+#! /usr/bin/env bash
+
+# Install script for VIPs. This only works if you have access to the servers.
+# Otherwise you will have to do the installation manually, as indicated in the
+# respective READMEs
+set -o errexit -o pipefail -o noclobber -o nounset
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/" && pwd)
+
+GITLAB=iis-git.ee.ethz.ch
+VIP_DIR=vip-proprietary
+AGREE_LICENSE=0
+USE_GITLAB=0
+
+cd "$ROOT"
+
+while [[ "$#" -gt 0 ]]; do case $1 in
+  -y|--yes) AGREE_LICENSE=1;;
+  -g|--gitlab) USE_GITLAB=1;;
+  *) echo "Unknown parameter passed: $1"; exit 1;;
+esac; shift; done
+
+if [[ "$AGREE_LICENSE" -ne "1" ]]; then
+    echo "You need to agree to all the licenses of all the VIPs in the rtl/vip
+    folder. If you do, pass --yes to this script"
+    exit 0
+fi
+if [[ ! -d "vip-proprietary" ]]; then
+    if [[ "$USE_GITLAB" -eq "1" ]]; then
+	git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@${GITLAB}/pulp-open/pulp-vip-proprietary \
+	    "$VIP_DIR"
+    else
+	git clone git@iis-git.ee.ethz.ch:pulp-open/pulp-vip-proprietary.git \
+	    "$VIP_DIR"
+    fi
+else
+    echo "The directory ${VIP_DIR} already exists, skipping git clone"
+fi
+echo "Installing i2c eeprom model"
+cp --verbose "$VIP_DIR"/24FC1025-i2c-eeprom/*.v i2c_eeprom/
+echo "Installing spi flash model"
+mkdir -p spi_flash/S25fs256s
+cp --verbose -r "$VIP_DIR"/S25fs256s-spi-flash/* spi_flash/S25fs256s
+echo "Installing i2s model"
+cp --verbose "$VIP_DIR"/24FC1025-i2c-eeprom/24FC1025.v i2s/i2c_if.v
+patch i2s/i2c_if.v < i2s/i2c_if_timings.patch

--- a/rtl/vip/i2s/i2c_if_timings.patch
+++ b/rtl/vip/i2s/i2c_if_timings.patch
@@ -1,0 +1,33 @@
+83c83
+< module M24FC1025 (A0, A1, A2, WP, SDA, SCL, RESET);
+---
+> module i2c_if (A0, A1, A2, WP, SDA, SCL, RESET,pdm_ddr,pdm_en,lsb_first,i2s_rst, i2s_mode, i2s_enable,transf_size,i2s_snap_enable);
+95a96,105
+>    output wire pdm_ddr;
+>    output wire pdm_en;
+>    output wire lsb_first;
+>    output wire i2s_rst;
+>    output wire i2s_mode;
+>    output wire i2s_enable;
+>    output wire i2s_snap_enable;
+>    output wire [1:0] transf_size;
+> 
+> 
+160,161c170,171
+<          tAA = 400;                 // SCL to SDA output delay
+<          tWC = 5000000;             // memory write cycle time
+---
+>          tAA = 100;                 // SCL to SDA output delay
+>          tWC = 100;             // memory write cycle time
+471a482,492
+> 
+>    assign pdm_ddr    = MemoryByte_000[0];
+>    assign pdm_en     = MemoryByte_000[1];    
+>    assign lsb_first  = MemoryByte_000[2];
+>    assign i2s_rst         = MemoryByte_000[3];
+>    assign i2s_mode        = MemoryByte_000[4];
+>    assign i2s_enable      = MemoryByte_000[5];
+>    assign transf_size[0]  = MemoryByte_000[6];
+>    assign transf_size[1]  = MemoryByte_000[7];
+>    assign i2s_snap_enable = MemoryByte_001[0];
+>    

--- a/rtl/vip/src_files.yml
+++ b/rtl/vip/src_files.yml
@@ -1,36 +1,37 @@
-# S25FS256_model:
-#   defines: [
-#     SPEEDSIM,
-#   ]
-#   files: [
-#     spi_flash/S25fs256s/model/s25fs256s.v,
-#   ]
-#   flags: [
-#     skip_synthesis,
-#   ]
+S25FS256_model:
+  defines: [
+    SPEEDSIM,
+  ]
+  files: [
+    spi_flash/S25fs256s/model/s25fs256s.v,
+  ]
+  flags: [
+    skip_synthesis,
+  ]
 
-# 24FC1025_model:
-#   defines: [
-#     SPEEDSIM,
-#   ]
-#   files: [
-#     i2c_eeprom/24FC1025.v,
-#   ]
-#   flags: [
-#     skip_synthesis,
+24FC1025_model:
+  defines: [
+    SPEEDSIM,
+  ]
+  files: [
+    i2c_eeprom/24FC1025.v,
+  ]
+  flags: [
+    skip_synthesis,
+  ]
 
-# i2s_model:
-#   defines: [
-#     SPEEDSIM,
-#   ]
-#   files: [
-#     i2s/i2s_if.v,
-#     i2s/i2s_vip_channel.v,
-#     i2s/i2s_vip.v,
-#   ]
-#   flags: [
-#     skip_synthesis,
-#   ]
+i2s_model:
+  defines: [
+    SPEEDSIM,
+  ]
+  files: [
+    i2s/i2c_if.v,
+    i2s/i2s_vip_channel.sv,
+    i2s/i2s_vip.sv,
+  ]
+  flags: [
+    skip_synthesis,
+  ]
 
 open_models:
   files: [

--- a/sdk-releases/get-sdk-2019.06.06-CentOS_7.py
+++ b/sdk-releases/get-sdk-2019.06.06-CentOS_7.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+# This file has been auto-generated and can be used for downloading the SDK it has
+# been generated for.
+
+import os
+import tarfile
+import os.path
+import argparse
+
+
+src="59b44701b6ac8390a97936cbd049256fc2917212"
+
+artefacts=[
+  ["https://iis-artifactory.ee.ethz.ch/artifactory/release/CentOS_7/pulp/sdk/mainstream/ece475907719cc96278ee907e48c2b801994a75f/0/sdk.tar.bz2", "pkg/sdk/2019.06.06"],
+  ["https://iis-artifactory.ee.ethz.ch/artifactory/release/CentOS_7/pulp/pulp_riscv_gcc/mainstream/1.0.13/0/pulp_riscv_gcc.tar.bz2", "pkg/pulp_riscv_gcc/1.0.13"]
+]
+
+exports=[
+  ["PULP_SDK_HOME", "$PULP_PROJECT_HOME/pkg/sdk/2019.06.06"],
+  ["PULP_SDK_INSTALL", "$PULP_SDK_HOME/install"],
+  ["PULP_SDK_WS_INSTALL", "$PULP_SDK_HOME/install/ws"],
+  ["PULP_RISCV_GCC_TOOLCHAIN_CI", "$PULP_PROJECT_HOME/pkg/pulp_riscv_gcc/1.0.13"],
+  ["CROSS_COMPILE", "$PULP_PROJECT_HOME/pkg/pulp_riscv_gcc/1.0.13/bin/riscv32-unknown-elf-"],
+  ["PULP_RISCV_GCC_VERSION", "3"],
+  ["ZEPHYR_GCC_VARIANT", "cross-compile"]
+]
+
+sourceme=[
+  ["$PULP_SDK_HOME/env/setup.sh", "$PULP_SDK_HOME/env/setup.csh"]
+]
+
+pkg=["sdk", "2019.06.06"]
+
+parser = argparse.ArgumentParser(description='PULP downloader')
+
+parser.add_argument('command', metavar='CMD', type=str, nargs='*',
+                   help='a command to be execute')
+
+parser.add_argument("--path", dest="path", default=None, help="Specify path where to install packages and sources")
+
+args = parser.parse_args()
+
+if len(args.command ) == 0:
+    args.command = ['get']
+
+if args.path != None:
+    path = os.path.expanduser(args.path)
+    if not os.path.exists(path):
+        os.makedirs(path)
+    os.chdir(path)
+
+for command in args.command:
+
+    if command == 'get' or command == 'download':
+
+        dir = os.getcwd()
+
+        if command == 'get':
+            if not os.path.exists('pkg'): os.makedirs('pkg')
+
+            os.chdir('pkg')
+
+        for artefactDesc in artefacts:
+            artefact = artefactDesc[0]
+            path = os.path.join(dir, artefactDesc[1])
+            urlList = artefact.split('/')
+            fileName = urlList[len(urlList)-1]
+
+            if command == 'download' or not os.path.exists(path):
+
+                if os.path.exists(fileName):
+                    os.remove(fileName)
+
+                if os.system('wget --no-check-certificate %s' % (artefact)) != 0:
+                    exit(-1)
+
+                if command == 'get':
+                    os.makedirs(path)
+                    t = tarfile.open(os.path.basename(artefact), 'r')
+                    t.extractall(path)
+                    os.remove(os.path.basename(artefact))
+
+        os.chdir(dir)
+
+    if command == 'get' or command == 'download' or command == 'env':
+
+        if not os.path.exists('env'):
+            os.makedirs('env')
+
+        filePath = 'env/env-%s-%s.sh' % (pkg[0], pkg[1])
+        with open(filePath, 'w') as envFile:
+            #envFile.write('export PULP_ENV_FILE_PATH=%s\n' % os.path.join(os.getcwd(), filePath))
+            #envFile.write('export PULP_SDK_SRC_PATH=%s\n' % os.environ.get("PULP_SDK_SRC_PATH"))
+            envFile.write('export %s=%s\n' % ('PULP_PROJECT_HOME', os.getcwd()))
+            for export in exports:
+                envFile.write('export %s=%s\n' % (export[0], export[1].replace('$PULP_PROJECT_HOME', os.getcwd())))
+            for env in sourceme:
+                envFile.write('source %s\n' % (env[0].replace('$PULP_PROJECT_HOME', os.getcwd())))
+            #envFile.write('if [ -e "$PULP_SDK_SRC_PATH/init.sh" ]; then source $PULP_SDK_SRC_PATH/init.sh; fi')
+
+        #filePath = 'env/env-%s-%s.csh' % (pkg[0], pkg[1])
+        #with open(filePath, 'w') as envFile:
+        #    envFile.write('setenv PULP_ENV_FILE_PATH %s\n' % os.path.join(os.getcwd(), filePath))
+        #    envFile.write('setenv PULP_SDK_SRC_PATH %s\n' % os.environ.get("PULP_SDK_SRC_PATH"))
+        #    for env in envFileStrCsh:
+        #        envFile.write('%s\n' % (env.replace('@PULP_PKG_HOME@', os.getcwd())))
+        #    envFile.write('if ( -e "$PULP_SDK_SRC_PATH/init.sh" ) then source $PULP_SDK_SRC_PATH/init.sh; endif')
+
+    if command == 'src':
+
+        if os.path.exists('.git'):
+            os.system('git checkout %s' % (src))
+        else:
+            os.system('git init .')
+            os.system('git remote add -t \* -f origin git@kesch.ee.ethz.ch:pulp-sw/pulp_pipeline.git')
+            os.system('git checkout %s' % (src))
+

--- a/sdk-releases/get-sdk-2019.07.01-CentOS_7.py
+++ b/sdk-releases/get-sdk-2019.07.01-CentOS_7.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+
+# This file has been auto-generated and can be used for downloading the SDK it has
+# been generated for.
+
+import os
+import tarfile
+import os.path
+import argparse
+
+
+src="59b44701b6ac8390a97936cbd049256fc2917212"
+
+artefacts=[
+  ["https://iis-artifactory.ee.ethz.ch/artifactory/release/CentOS_7/pulp/sdk/mainstream/5ca4920d55968ca2797d85a33aee62adf3663fd0/0/sdk.tar.bz2", "pkg/sdk/2019.07.01"],
+  ["https://iis-artifactory.ee.ethz.ch/artifactory/release/CentOS_7/pulp/pulp_riscv_gcc/mainstream/1.0.13/0/pulp_riscv_gcc.tar.bz2", "pkg/pulp_riscv_gcc/1.0.13"],
+  ["https://iis-artifactory.ee.ethz.ch/artifactory/release/pulp/gap/mainstream/1.3/0/gap.tar.bz2", "pkg/rtl/gap/1.3"]
+]
+
+exports=[
+  ["PULP_SDK_HOME", "$PULP_PROJECT_HOME/pkg/sdk/2019.07.01"],
+  ["PULP_SDK_INSTALL", "$PULP_SDK_HOME/install"],
+  ["PULP_SDK_WS_INSTALL", "$PULP_SDK_HOME/install/ws"],
+  ["PULP_RISCV_GCC_TOOLCHAIN_CI", "$PULP_PROJECT_HOME/pkg/pulp_riscv_gcc/1.0.13"],
+  ["CROSS_COMPILE", "$PULP_PROJECT_HOME/pkg/pulp_riscv_gcc/1.0.13/bin/riscv32-unknown-elf-"],
+  ["PULP_RISCV_GCC_VERSION", "3"],
+  ["ZEPHYR_GCC_VARIANT", "cross-compile"],
+  ["PULP_RTL_GAP", "$PULP_PROJECT_HOME/pkg/rtl/gap/1.3"]
+]
+
+sourceme=[
+  ["$PULP_SDK_HOME/env/setup.sh", "$PULP_SDK_HOME/env/setup.csh"]
+]
+
+pkg=["sdk", "2019.07.01"]
+
+parser = argparse.ArgumentParser(description='PULP downloader')
+
+parser.add_argument('command', metavar='CMD', type=str, nargs='*',
+                   help='a command to be execute')
+
+parser.add_argument("--path", dest="path", default=None, help="Specify path where to install packages and sources")
+
+args = parser.parse_args()
+
+if len(args.command ) == 0:
+    args.command = ['get']
+
+if args.path != None:
+    path = os.path.expanduser(args.path)
+    if not os.path.exists(path):
+        os.makedirs(path)
+    os.chdir(path)
+
+for command in args.command:
+
+    if command == 'get' or command == 'download':
+
+        dir = os.getcwd()
+
+        if command == 'get':
+            if not os.path.exists('pkg'): os.makedirs('pkg')
+
+            os.chdir('pkg')
+
+        for artefactDesc in artefacts:
+            artefact = artefactDesc[0]
+            path = os.path.join(dir, artefactDesc[1])
+            urlList = artefact.split('/')
+            fileName = urlList[len(urlList)-1]
+
+            if command == 'download' or not os.path.exists(path):
+
+                if os.path.exists(fileName):
+                    os.remove(fileName)
+
+                print('ARTIFACTORY DUMP')
+                artifactory_user = os.environ['ARTIFACTORY_USER']
+                artifactory_pw = os.environ['ARTIFACTORY_PASSWORD']
+
+                if os.system('wget -nv --timeout=2 --user %s --password %s --no-check-certificate %s' % (artifactory_user, artifactory_pw, artefact)) != 0:
+                    exit(-1)
+
+                if command == 'get':
+                    os.makedirs(path)
+                    t = tarfile.open(os.path.basename(artefact), 'r')
+                    t.extractall(path)
+                    os.remove(os.path.basename(artefact))
+
+        os.chdir(dir)
+
+    if command == 'get' or command == 'download' or command == 'env':
+
+        if not os.path.exists('env'):
+            os.makedirs('env')
+
+        filePath = 'env/env-%s-%s.sh' % (pkg[0], pkg[1])
+        with open(filePath, 'w') as envFile:
+            #envFile.write('export PULP_ENV_FILE_PATH=%s\n' % os.path.join(os.getcwd(), filePath))
+            #envFile.write('export PULP_SDK_SRC_PATH=%s\n' % os.environ.get("PULP_SDK_SRC_PATH"))
+            envFile.write('export %s=%s\n' % ('PULP_PROJECT_HOME', os.getcwd()))
+            for export in exports:
+                envFile.write('export %s=%s\n' % (export[0], export[1].replace('$PULP_PROJECT_HOME', os.getcwd())))
+            for env in sourceme:
+                envFile.write('source %s\n' % (env[0].replace('$PULP_PROJECT_HOME', os.getcwd())))
+            #envFile.write('if [ -e "$PULP_SDK_SRC_PATH/init.sh" ]; then source $PULP_SDK_SRC_PATH/init.sh; fi')
+
+        #filePath = 'env/env-%s-%s.csh' % (pkg[0], pkg[1])
+        #with open(filePath, 'w') as envFile:
+        #    envFile.write('setenv PULP_ENV_FILE_PATH %s\n' % os.path.join(os.getcwd(), filePath))
+        #    envFile.write('setenv PULP_SDK_SRC_PATH %s\n' % os.environ.get("PULP_SDK_SRC_PATH"))
+        #    for env in envFileStrCsh:
+        #        envFile.write('%s\n' % (env.replace('@PULP_PKG_HOME@', os.getcwd())))
+        #    envFile.write('if ( -e "$PULP_SDK_SRC_PATH/init.sh" ) then source $PULP_SDK_SRC_PATH/init.sh; endif')
+
+    if command == 'src':
+
+        if os.path.exists('.git'):
+            os.system('git checkout %s' % (src))
+        else:
+            os.system('git init .')
+            os.system('git remote add -t \* -f origin git@kesch.ee.ethz.ch:pulp-sw/pulp_pipeline.git')
+            os.system('git checkout %s' % (src))
+

--- a/sdk-releases/get-sdk-2019.10.02-CentOS_7.py
+++ b/sdk-releases/get-sdk-2019.10.02-CentOS_7.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+
+# This file has been auto-generated and can be used for downloading the SDK it has
+# been generated for.
+
+import os
+import tarfile
+import os.path
+import argparse
+
+
+src="59b44701b6ac8390a97936cbd049256fc2917212"
+
+artefacts=[
+  ["https://iis-artifactory.ee.ethz.ch/artifactory/release/CentOS_7/pulp/sdk/mainstream/df5e21e69b569cb0956e281b9571a5d4a5db000e/0/sdk.tar.bz2", "pkg/sdk/2019.10.02"],
+  ["https://iis-artifactory.ee.ethz.ch/artifactory/release/CentOS_7/pulp/pulp_riscv_gcc/mainstream/1.0.14/0/pulp_riscv_gcc.tar.bz2", "pkg/pulp_riscv_gcc/1.0.14"]
+]
+
+exports=[
+  ["PULP_SDK_HOME", "$PULP_PROJECT_HOME/pkg/sdk/2019.10.02"],
+  ["PULP_SDK_INSTALL", "$PULP_SDK_HOME/install"],
+  ["PULP_SDK_WS_INSTALL", "$PULP_SDK_HOME/install/ws"],
+  ["PULP_RISCV_GCC_TOOLCHAIN_CI", "$PULP_PROJECT_HOME/pkg/pulp_riscv_gcc/1.0.14"],
+  ["CROSS_COMPILE", "$PULP_PROJECT_HOME/pkg/pulp_riscv_gcc/1.0.14/bin/riscv32-unknown-elf-"],
+  ["PULP_RISCV_GCC_VERSION", "3"],
+  ["ZEPHYR_GCC_VARIANT", "cross-compile"]
+]
+
+sourceme=[
+  ["$PULP_SDK_HOME/env/setup.sh", "$PULP_SDK_HOME/env/setup.csh"]
+]
+
+pkg=["sdk", "2019.10.02"]
+
+parser = argparse.ArgumentParser(description='PULP downloader')
+
+parser.add_argument('command', metavar='CMD', type=str, nargs='*',
+                   help='a command to be execute')
+
+parser.add_argument("--path", dest="path", default=None, help="Specify path where to install packages and sources")
+
+args = parser.parse_args()
+
+if len(args.command ) == 0:
+    args.command = ['get']
+
+if args.path != None:
+    path = os.path.expanduser(args.path)
+    if not os.path.exists(path):
+        os.makedirs(path)
+    os.chdir(path)
+
+for command in args.command:
+
+    if command == 'get' or command == 'download':
+
+        dir = os.getcwd()
+
+        if command == 'get':
+            if not os.path.exists('pkg'): os.makedirs('pkg')
+
+            os.chdir('pkg')
+
+        for artefactDesc in artefacts:
+            artefact = artefactDesc[0]
+            path = os.path.join(dir, artefactDesc[1])
+            urlList = artefact.split('/')
+            fileName = urlList[len(urlList)-1]
+
+            if command == 'download' or not os.path.exists(path):
+
+                if os.path.exists(fileName):
+                    os.remove(fileName)
+
+                artifactory_user = os.environ['ARTIFACTORY_USER']
+                artifactory_pw = os.environ['ARTIFACTORY_PASSWORD']
+
+                if os.system('wget -nv --timeout=2 --user %s --password %s --no-check-certificate %s' % (artifactory_user, artifactory_pw, artefact)) != 0:
+                    exit(-1)
+
+                if command == 'get':
+                    os.makedirs(path)
+                    t = tarfile.open(os.path.basename(artefact), 'r')
+                    t.extractall(path)
+                    os.remove(os.path.basename(artefact))
+
+        os.chdir(dir)
+
+    if command == 'get' or command == 'download' or command == 'env':
+
+        if not os.path.exists('env'):
+            os.makedirs('env')
+
+        filePath = 'env/env-%s-%s.sh' % (pkg[0], pkg[1])
+        with open(filePath, 'w') as envFile:
+            #envFile.write('export PULP_ENV_FILE_PATH=%s\n' % os.path.join(os.getcwd(), filePath))
+            #envFile.write('export PULP_SDK_SRC_PATH=%s\n' % os.environ.get("PULP_SDK_SRC_PATH"))
+            envFile.write('export %s=%s\n' % ('PULP_PROJECT_HOME', os.getcwd()))
+            for export in exports:
+                envFile.write('export %s=%s\n' % (export[0], export[1].replace('$PULP_PROJECT_HOME', os.getcwd())))
+            for env in sourceme:
+                envFile.write('source %s\n' % (env[0].replace('$PULP_PROJECT_HOME', os.getcwd())))
+            #envFile.write('if [ -e "$PULP_SDK_SRC_PATH/init.sh" ]; then source $PULP_SDK_SRC_PATH/init.sh; fi')
+
+        #filePath = 'env/env-%s-%s.csh' % (pkg[0], pkg[1])
+        #with open(filePath, 'w') as envFile:
+        #    envFile.write('setenv PULP_ENV_FILE_PATH %s\n' % os.path.join(os.getcwd(), filePath))
+        #    envFile.write('setenv PULP_SDK_SRC_PATH %s\n' % os.environ.get("PULP_SDK_SRC_PATH"))
+        #    for env in envFileStrCsh:
+        #        envFile.write('%s\n' % (env.replace('@PULP_PKG_HOME@', os.getcwd())))
+        #    envFile.write('if ( -e "$PULP_SDK_SRC_PATH/init.sh" ) then source $PULP_SDK_SRC_PATH/init.sh; endif')
+
+    if command == 'src':
+
+        if os.path.exists('.git'):
+            os.system('git checkout %s' % (src))
+        else:
+            os.system('git init .')
+            os.system('git remote add -t \* -f origin git@kesch.ee.ethz.ch:pulp-sw/pulp_pipeline.git')
+            os.system('git checkout %s' % (src))
+

--- a/sdk-releases/get-sdk-2019.11.02-CentOS_7.py
+++ b/sdk-releases/get-sdk-2019.11.02-CentOS_7.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+
+# This file has been auto-generated and can be used for downloading the SDK it has
+# been generated for.
+
+import os
+import tarfile
+import os.path
+import argparse
+
+
+src="59b44701b6ac8390a97936cbd049256fc2917212"
+
+artefacts=[
+  ["https://iis-artifactory.ee.ethz.ch/artifactory/release/CentOS_7/pulp/sdk/mainstream/6d315498fd4a31a4f54f5afb2805fbc1a6c382b9/0/sdk.tar.bz2", "pkg/sdk/2019.11.02"],
+  ["https://iis-artifactory.ee.ethz.ch/artifactory/release/CentOS_7/pulp/pulp_riscv_gcc/mainstream/1.0.14/0/pulp_riscv_gcc.tar.bz2", "pkg/pulp_riscv_gcc/1.0.14"]
+]
+
+exports=[
+  ["PULP_SDK_HOME", "$PULP_PROJECT_HOME/pkg/sdk/2019.11.02"],
+  ["PULP_SDK_INSTALL", "$PULP_SDK_HOME/install"],
+  ["PULP_SDK_WS_INSTALL", "$PULP_SDK_HOME/install/ws"],
+  ["PULP_RISCV_GCC_TOOLCHAIN_CI", "$PULP_PROJECT_HOME/pkg/pulp_riscv_gcc/1.0.14"],
+  ["CROSS_COMPILE", "$PULP_PROJECT_HOME/pkg/pulp_riscv_gcc/1.0.14/bin/riscv32-unknown-elf-"],
+  ["PULP_RISCV_GCC_VERSION", "3"],
+  ["ZEPHYR_GCC_VARIANT", "cross-compile"]
+]
+
+sourceme=[
+  ["$PULP_SDK_HOME/env/setup.sh", "$PULP_SDK_HOME/env/setup.csh"]
+]
+
+pkg=["sdk", "2019.11.02"]
+
+parser = argparse.ArgumentParser(description='PULP downloader')
+
+parser.add_argument('command', metavar='CMD', type=str, nargs='*',
+                   help='a command to be execute')
+
+parser.add_argument("--path", dest="path", default=None, help="Specify path where to install packages and sources")
+
+args = parser.parse_args()
+
+if len(args.command ) == 0:
+    args.command = ['get']
+
+if args.path != None:
+    path = os.path.expanduser(args.path)
+    if not os.path.exists(path):
+        os.makedirs(path)
+    os.chdir(path)
+
+for command in args.command:
+
+    if command == 'get' or command == 'download':
+
+        dir = os.getcwd()
+
+        if command == 'get':
+            if not os.path.exists('pkg'): os.makedirs('pkg')
+
+            os.chdir('pkg')
+
+        for artefactDesc in artefacts:
+            artefact = artefactDesc[0]
+            path = os.path.join(dir, artefactDesc[1])
+            urlList = artefact.split('/')
+            fileName = urlList[len(urlList)-1]
+
+            if command == 'download' or not os.path.exists(path):
+
+                if os.path.exists(fileName):
+                    os.remove(fileName)
+
+                artifactory_user = os.environ['ARTIFACTORY_USER']
+                artifactory_pw = os.environ['ARTIFACTORY_PASSWORD']
+
+                if os.system('wget -nv --timeout=2 --user %s --password %s --no-check-certificate %s' % (artifactory_user, artifactory_pw, artefact)) != 0:
+                    exit(-1)
+
+                if command == 'get':
+                    os.makedirs(path)
+                    t = tarfile.open(os.path.basename(artefact), 'r')
+                    t.extractall(path)
+                    os.remove(os.path.basename(artefact))
+
+        os.chdir(dir)
+
+    if command == 'get' or command == 'download' or command == 'env':
+
+        if not os.path.exists('env'):
+            os.makedirs('env')
+
+        filePath = 'env/env-%s-%s.sh' % (pkg[0], pkg[1])
+        with open(filePath, 'w') as envFile:
+            #envFile.write('export PULP_ENV_FILE_PATH=%s\n' % os.path.join(os.getcwd(), filePath))
+            #envFile.write('export PULP_SDK_SRC_PATH=%s\n' % os.environ.get("PULP_SDK_SRC_PATH"))
+            envFile.write('export %s=%s\n' % ('PULP_PROJECT_HOME', os.getcwd()))
+            for export in exports:
+                envFile.write('export %s=%s\n' % (export[0], export[1].replace('$PULP_PROJECT_HOME', os.getcwd())))
+            for env in sourceme:
+                envFile.write('source %s\n' % (env[0].replace('$PULP_PROJECT_HOME', os.getcwd())))
+            #envFile.write('if [ -e "$PULP_SDK_SRC_PATH/init.sh" ]; then source $PULP_SDK_SRC_PATH/init.sh; fi')
+
+        #filePath = 'env/env-%s-%s.csh' % (pkg[0], pkg[1])
+        #with open(filePath, 'w') as envFile:
+        #    envFile.write('setenv PULP_ENV_FILE_PATH %s\n' % os.path.join(os.getcwd(), filePath))
+        #    envFile.write('setenv PULP_SDK_SRC_PATH %s\n' % os.environ.get("PULP_SDK_SRC_PATH"))
+        #    for env in envFileStrCsh:
+        #        envFile.write('%s\n' % (env.replace('@PULP_PKG_HOME@', os.getcwd())))
+        #    envFile.write('if ( -e "$PULP_SDK_SRC_PATH/init.sh" ) then source $PULP_SDK_SRC_PATH/init.sh; endif')
+
+    if command == 'src':
+
+        if os.path.exists('.git'):
+            os.system('git checkout %s' % (src))
+        else:
+            os.system('git init .')
+            os.system('git remote add -t \* -f origin git@kesch.ee.ethz.ch:pulp-sw/pulp_pipeline.git')
+            os.system('git checkout %s' % (src))
+

--- a/sdk-releases/get-sdk-2019.11.03-CentOS_7.py
+++ b/sdk-releases/get-sdk-2019.11.03-CentOS_7.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+
+# This file has been auto-generated and can be used for downloading the SDK it has
+# been generated for.
+
+import os
+import tarfile
+import os.path
+import argparse
+
+
+src="59b44701b6ac8390a97936cbd049256fc2917212"
+
+artefacts=[
+  ["https://iis-artifactory.ee.ethz.ch/artifactory/release/CentOS_7/pulp/sdk/mainstream/77d1afe6d11d9935dd6a36617d420a5bdb19f95e/0/sdk.tar.bz2", "pkg/sdk/2019.11.03"],
+  ["https://iis-artifactory.ee.ethz.ch/artifactory/release/CentOS_7/pulp/pulp_riscv_gcc/mainstream/1.0.14/0/pulp_riscv_gcc.tar.bz2", "pkg/pulp_riscv_gcc/1.0.14"]
+]
+
+exports=[
+  ["PULP_SDK_HOME", "$PULP_PROJECT_HOME/pkg/sdk/2019.11.03"],
+  ["PULP_SDK_INSTALL", "$PULP_SDK_HOME/install"],
+  ["PULP_SDK_WS_INSTALL", "$PULP_SDK_HOME/install/ws"],
+  ["PULP_RISCV_GCC_TOOLCHAIN_CI", "$PULP_PROJECT_HOME/pkg/pulp_riscv_gcc/1.0.14"],
+  ["CROSS_COMPILE", "$PULP_PROJECT_HOME/pkg/pulp_riscv_gcc/1.0.14/bin/riscv32-unknown-elf-"],
+  ["PULP_RISCV_GCC_VERSION", "3"],
+  ["ZEPHYR_GCC_VARIANT", "cross-compile"]
+]
+
+sourceme=[
+  ["$PULP_SDK_HOME/env/setup.sh", "$PULP_SDK_HOME/env/setup.csh"]
+]
+
+pkg=["sdk", "2019.11.03"]
+
+parser = argparse.ArgumentParser(description='PULP downloader')
+
+parser.add_argument('command', metavar='CMD', type=str, nargs='*',
+                   help='a command to be execute')
+
+parser.add_argument("--path", dest="path", default=None, help="Specify path where to install packages and sources")
+parser.add_argument("--nv", dest="nv", action="store_true", help="Deactivate verbosity")
+
+args = parser.parse_args()
+
+if len(args.command ) == 0:
+    args.command = ['get']
+
+if args.path != None:
+    path = os.path.expanduser(args.path)
+    if not os.path.exists(path):
+        os.makedirs(path)
+    os.chdir(path)
+
+for command in args.command:
+
+    if command == 'get' or command == 'download':
+
+        dir = os.getcwd()
+
+        if command == 'get':
+            if not os.path.exists('pkg'): os.makedirs('pkg')
+
+            os.chdir('pkg')
+
+        for artefactDesc in artefacts:
+            artefact = artefactDesc[0]
+            path = os.path.join(dir, artefactDesc[1])
+            urlList = artefact.split('/')
+            fileName = urlList[len(urlList)-1]
+
+            if command == 'download' or not os.path.exists(path):
+
+                if os.path.exists(fileName):
+                    os.remove(fileName)
+
+
+                artifactory_user = os.environ.get('PULP_ARTIFACTORY_USER')
+
+                wget_opt = ''
+                if args.nv:
+                    wget_opt += ' -nv'
+
+                if artifactory_user is not None:
+                    artifactory_user, artifactory_pw = artifactory_user.split(':')
+                    if os.system('wget %s --timeout=2 --user %s --password %s --no-check-certificate %s' % (wget_opt, artifactory_user, artifactory_pw, artefact)) != 0:
+                        exit(-1)
+                else:
+                    if os.system('wget %s --timeout=2 --no-check-certificate %s' % (wget_opt, artefact)) != 0:
+                        exit(-1)
+
+                if command == 'get':
+                    os.makedirs(path)
+                    t = tarfile.open(os.path.basename(artefact), 'r')
+                    t.extractall(path)
+                    os.remove(os.path.basename(artefact))
+
+        os.chdir(dir)
+
+    if command == 'get' or command == 'download' or command == 'env':
+
+        if not os.path.exists('env'):
+            os.makedirs('env')
+
+        filePath = 'env/env-%s-%s.sh' % (pkg[0], pkg[1])
+        with open(filePath, 'w') as envFile:
+            #envFile.write('export PULP_ENV_FILE_PATH=%s\n' % os.path.join(os.getcwd(), filePath))
+            #envFile.write('export PULP_SDK_SRC_PATH=%s\n' % os.environ.get("PULP_SDK_SRC_PATH"))
+            envFile.write('export %s=%s\n' % ('PULP_PROJECT_HOME', os.getcwd()))
+            for export in exports:
+                envFile.write('export %s=%s\n' % (export[0], export[1].replace('$PULP_PROJECT_HOME', os.getcwd())))
+            for env in sourceme:
+                envFile.write('source %s\n' % (env[0].replace('$PULP_PROJECT_HOME', os.getcwd())))
+            #envFile.write('if [ -e "$PULP_SDK_SRC_PATH/init.sh" ]; then source $PULP_SDK_SRC_PATH/init.sh; fi')
+
+        #filePath = 'env/env-%s-%s.csh' % (pkg[0], pkg[1])
+        #with open(filePath, 'w') as envFile:
+        #    envFile.write('setenv PULP_ENV_FILE_PATH %s\n' % os.path.join(os.getcwd(), filePath))
+        #    envFile.write('setenv PULP_SDK_SRC_PATH %s\n' % os.environ.get("PULP_SDK_SRC_PATH"))
+        #    for env in envFileStrCsh:
+        #        envFile.write('%s\n' % (env.replace('@PULP_PKG_HOME@', os.getcwd())))
+        #    envFile.write('if ( -e "$PULP_SDK_SRC_PATH/init.sh" ) then source $PULP_SDK_SRC_PATH/init.sh; endif')
+
+    if command == 'src':
+
+        if os.path.exists('.git'):
+            os.system('git checkout %s' % (src))
+        else:
+            os.system('git init .')
+            os.system('git remote add -t \* -f origin git@kesch.ee.ethz.ch:pulp-sw/pulp_pipeline.git')
+            os.system('git checkout %s' % (src))
+

--- a/sdk-releases/pulp-sdk-2019.07.01-junit.patch
+++ b/sdk-releases/pulp-sdk-2019.07.01-junit.patch
@@ -1,0 +1,13 @@
+diff --git a/sdk/2019.07.01/install/ws/python/plpobjects.py b/sdk/2019.07.01/install/ws/python/plpobjects.py
+index ecf7ae7..3eae00f 100755
+--- a/sdk/2019.07.01/install/ws/python/plpobjects.py
++++ b/sdk/2019.07.01/install/ws/python/plpobjects.py
+@@ -357,7 +357,7 @@ class Test(object):
+ 
+         for run in self.runs:
+ 
+-            testFile.write('  <testcase classname="%s" name="%s" time="%f">\n' % (test_prefix + ':' + name, run.config, run.duration))
++            testFile.write('  <testcase classname="%s" name="%s" time="%f">\n' % (run.config, test_prefix + ':' + name, run.duration))
+             if run.success:
+                 testFile.write('    <success/>\n')
+             else:

--- a/sdk-releases/pulp-sdk-2019.10.02-junit.patch
+++ b/sdk-releases/pulp-sdk-2019.10.02-junit.patch
@@ -1,0 +1,14 @@
+diff --git a/sdk/2019.10.02/install/ws/python/plpobjects.py b/sdk/2019.10.02/install/ws/python/plpobjects.py
+index ecf7ae7..93cb1e9 100755
+--- a/sdk/2019.10.02/install/ws/python/plpobjects.py
++++ b/sdk/2019.10.02/install/ws/python/plpobjects.py
+@@ -357,7 +357,7 @@ class Test(object):
+ 
+         for run in self.runs:
+ 
+-            testFile.write('  <testcase classname="%s" name="%s" time="%f">\n' % (test_prefix + ':' + name, run.config, run.duration))
++            testFile.write('  <testcase classname="%s" name="%s" time="%f">\n' % (run.config, test_prefix + ':' + name, run.duration))
+             if run.success:
+                 testFile.write('    <success/>\n')
+             else:
+

--- a/sdk-releases/pulp-sdk-2019.11.02-junit.patch
+++ b/sdk-releases/pulp-sdk-2019.11.02-junit.patch
@@ -1,0 +1,14 @@
+diff --git a/sdk/2019.11.02/install/ws/python/plpobjects.py b/sdk/2019.11.02/install/ws/python/plpobjects.py
+index ecf7ae7..93cb1e9 100755
+--- a/sdk/2019.11.02/install/ws/python/plpobjects.py
++++ b/sdk/2019.11.02/install/ws/python/plpobjects.py
+@@ -357,7 +357,7 @@ class Test(object):
+ 
+         for run in self.runs:
+ 
+-            testFile.write('  <testcase classname="%s" name="%s" time="%f">\n' % (test_prefix + ':' + name, run.config, run.duration))
++            testFile.write('  <testcase classname="%s" name="%s" time="%f">\n' % (run.config, test_prefix + ':' + name, run.duration))
+             if run.success:
+                 testFile.write('    <success/>\n')
+             else:
+

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -10,6 +10,13 @@ SVLIB	    =  ../rtl/tb/remote_bitbang/librbs
 
 all: clean lib build opt
 
+# build the bitbang library, needed for simulating a jtag bridge to OpenOCD
+build-deps:
+	$(MAKE) -C ../rtl/tb/remote_bitbang all
+
+clean-deps:
+	$(MAKE) -C ../rtl/tb/remote_bitbang clean
+
 sim:
 	$(VSIM) -64 -gui vopt_tb -L models_lib -L vip_lib \
 		-suppress vsim-3009 -suppress vsim-8683 \
@@ -29,7 +36,7 @@ simc:
 opt:
 	$(mkfile_path)/tcl_files/rtl_vopt.tcl
 
-build:
+build: build-deps
 	@make --no-print-directory -f $(mkfile_path)/vcompile/ips.mk build
 	@make --no-print-directory -f $(mkfile_path)/vcompile/rtl.mk build
 
@@ -37,6 +44,6 @@ lib:
 	@make --no-print-directory -f $(mkfile_path)/vcompile/ips.mk lib
 	@make --no-print-directory -f $(mkfile_path)/vcompile/rtl.mk lib
 
-clean:
+clean: clean-deps
 	@make --no-print-directory -f $(mkfile_path)/vcompile/ips.mk clean
 	@make --no-print-directory -f $(mkfile_path)/vcompile/rtl.mk clean

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,70 @@
+# Tests
+You can run tests either locally in a manual fashion or use your GitLab CI
+instance. The latter is meant for internal usage.
+
+## Running software tests manually
+Call the `./update-tests` script in the top-level directory. This populate this
+directory with all software tests.
+
+Make sure you have [configured](https://github.com/pulp-platform/pulp-sdk) your
+SDK. You can now run single tests by using the provided Makefiles or use
+`plptest --testset path-to-testset.cfg`. Other useful flags you can set for
+`plptest` are `--stdout` to dump the output to stdout and `--threads` to run
+multiple tests at once.
+
+After the tests complete you will have JUnit reports for each `testset.cfg`
+placed in the `junit-reports` directory.
+
+## Adding your own tests
+You can add your own tests by putting them in a repository and adding them to
+`update-tests` and `update-tests-gitlab` scripts in the top-level folder. Make
+sure you define an appropriate `testset.cfg` that lists all the tests in your
+repository and for each test provide another `testset.cfg` with instructions on
+how to run it. Have a look at the already existing tests for an idea how such
+files should look like.
+
+## Setting up CI
+A brief explanation on how to set up GitLab CI for this project.
+
+### Prerequisites
+- Questasim accessible from the GitLab instance
+- Vivado accessible from the GitLab instance
+- Access to the ETH Artifactory server. This is required to download the PULP
+  SDK release versions. Alternatively, you can also always fetch the latest SDK
+  sources and let it be built and used for running the tests. This approach is
+  not recommended.
+- Centos7 runners
+
+### Steps
+1. Import this repository to GitLab. Using the GitLab import functionality is
+   recommended.
+2. Under Settings -> Repository -> Variables add the following environment
+   variables:
+   - `ARTIFACTORY_USER`
+   - `ARTIFACTORY_PASSWORD`
+   - `PULP_ARTIFACTORY_USER`
+
+   with their respective values. Make sure you check the mask tick box on all of
+   these.
+
+   This is a redundant set of variables for backward compatibility reasons
+3. The `.gitlab-ci.yml` file should be auto-detected by GitLab and start running
+   test instances whenever you push commits.
+4. Inspect the current running tests instances (pipelines) under CI/CD ->
+   Pipelines. Here you can stop instances you deem unnecessary but you can also
+   launch such manually for any branch by using the green `Run Pipeline` button.
+
+### Artifacts and Reports
+Test instances produce a set of outputs called artifacts and reports. They can
+be downloaded from the GitLab interface.
+
+Reports are `JUnit.xml` documents and for convenience HTML renderings
+thereof. These are used to inspect test results.
+
+Artifacts are more general byproducts of the different execution stages of a
+pipeline. In this repository each stage saves nearly all its relevant output.
+While these artifacts can be used for debugging, what you mostly want is
+inspecting the FPGA build results (bitstream, reports).
+
+
+

--- a/tests/testset.cfg
+++ b/tests/testset.cfg
@@ -4,7 +4,7 @@ from plptest import *
 TestConfig = c = {}
 
 tests = Testset(
-  name  = 'tests',
+  name  = 'PULP Software Tests',
   files = [ 
     "ml_tests/testset.cfg",
     "parallel_bare_tests/testset.cfg",

--- a/update-ips
+++ b/update-ips
@@ -5,6 +5,28 @@
 # All rights reserved.
 
 from ipstools_cfg import *
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(
+    prog='PULP update script',
+    description="""Fetch IPs and resolve dependencies for PULPissimo""")
+
+parser.add_argument('--rt-dpi', action='store_true',
+                    help='Use the PULP Runtime DPI to emulate peripherals')
+parser.add_argument('--i2c-vip', action='store_true',
+                    help="""Use the i2c model (24FC1025).
+                    Needs to be installed.""")
+parser.add_argument('--flash-vip', action='store_true',
+                    help="""Use the flash model (S25FS256).
+                    Needs to be installed.""")
+parser.add_argument('--i2s-vip', action='store_true',
+                    help="""Use the i2s model (24FC1025).
+                    Needs to be installed.""")
+parser.add_argument('--verbose', action='store_true',
+                    help='Show more information about commands')
+
+args = parser.parse_args()
 
 try:
     os.mkdir("ips")
@@ -18,12 +40,15 @@ ipdb = ipstools.IPDatabase(
     rtl_dir='rtl',
     ips_dir='ips',
     vsim_dir='sim',
-    default_server=DEFAULT_SERVER
+    default_server=DEFAULT_SERVER,
+    verbose=args.verbose
 )
 # updates the IPs from the git repo
 ipdb.update_ips()
 
 # launch generate-ips.py
 ipdb.save_database()
-execute("./generate-scripts")
+
+# pass arguments and call generate script
+execute("./generate-scripts " + (' '.join(sys.argv[1:])))
 

--- a/update-tests-gitlab
+++ b/update-tests-gitlab
@@ -1,18 +1,20 @@
 #!/bin/bash -e
+# This script is solely used on gitlab
 
-# This is the script you use when you do a local test
+GITLAB=iis-git.ee.ethz.ch
+
 # getting tests
-git clone git@iis-git.ee.ethz.ch:pulp-tests/ml_tests.git \
+git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@${GITLAB}/pulp-tests/ml_tests.git \
     tests/ml_tests
-git clone git@iis-git.ee.ethz.ch:pulp-sw/pulp_tests.git \
+git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@${GITLAB}/pulp-sw/pulp_tests.git \
     tests/pulp_tests
-git clone git@iis-git.ee.ethz.ch:pulp-tests/rt-tests.git \
+git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@${GITLAB}/pulp-tests/rt-tests.git \
     tests/rt-tests
-git clone git@iis-git.ee.ethz.ch:pulp-sw/parallel_bare_tests.git \
+git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@${GITLAB}/pulp-sw/parallel_bare_tests.git \
     tests/parallel_bare_tests
-git clone git@iis-git.ee.ethz.ch:pulp-sw/riscv_tests.git \
+git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@${GITLAB}/pulp-sw/riscv_tests.git \
     tests/riscv_tests
-git clone git@iis-git.ee.ethz.ch:pulp-sw/sequential_bare_tests.git \
+git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@${GITLAB}/pulp-sw/sequential_bare_tests.git \
     tests/sequential_bare_tests
 
 # using "stable" versions


### PR DESCRIPTION
Ported mostly from PULPissimo
* Add gitlab CI support (.gitlab-ci.yml)
  update-tests-gitlab fetches tests for gitlab ci instance
  Add tests folder to reduce clutter in toplevel folder
  Update Makefile with new gitlab targets

* Pin update-tests and update-tests-gitlab to specific test
  versions (latest atm)

* sdk-releases scripts
  These scripts pull sdk releases from artifactory for testing

* Add auto installing and handling for VIPs, adjust generate-script and
  update-ips for that
  Check the following flags:
  `[-h] [--rt-dpi] [--i2c-vip] [--flash-vip] [--i2s-vip] [--verbose]`