### PR TITLE
Updated ips list with newer version of pulp_cluster

### DIFF
--- a/ips_list.yml
+++ b/ips_list.yml
@@ -24,7 +24,7 @@ pulp_soc:
   group:  pulp-platform
 
 pulp_cluster:
-  commit: 741bbc945213b6367c89ee668960dcdfeaf1c8d0
+  commit: pulp_cluster_v1.0
   server: https://github.com
   group:  pulp-platform
 


### PR DESCRIPTION
Updated IPS list with newer version of the cluster.
The cluster have the following IPs updated :
-PER2AXI
-EVENT_UNIT_FLEX
-HIER_ICACHE
-FPU_INTERCO