### PR TITLE
pulp_soc: bump to v1.4.0, update i2c & spi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+/.cached*
+/__pycache__*
+/ips
+/ipstools
+/sim/modelsim*
+/sim/ncompile/*
+!/sim/ncompile/build.mk
+/tests/*/

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -19,7 +19,7 @@
 #
 
 pulp_soc:
-  commit: v1.2.0
+  commit: v1.4.0
   server: https://github.com
   group:  pulp-platform
 

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -19,7 +19,7 @@
 #
 
 pulp_soc:
-  commit: v1.1.0
+  commit: v1.2.0
   server: https://github.com
   group:  pulp-platform
 

--- a/rtl/pulp/pad_control.sv
+++ b/rtl/pulp/pad_control.sv
@@ -24,64 +24,64 @@ module pad_control #(
         //********************************************************************//
 
         // PAD CONTROL REGISTER
-        input  logic [63:0][1:0] pad_mux_i            ,
-        input  logic [63:0][5:0] pad_cfg_i            ,
-        output logic [47:0][5:0] pad_cfg_o            ,
+        input  logic [63:0][1:0] pad_mux_i        ,
+        input  logic [63:0][5:0] pad_cfg_i        ,
+        output logic [47:0][5:0] pad_cfg_o        ,
 
-        input  logic             sdio_clk_i,
-        input  logic             sdio_cmd_i,
-        output logic             sdio_cmd_o,
-        input  logic             sdio_cmd_oen_i,
-        input  logic [3:0]       sdio_data_i,
-        output logic [3:0]       sdio_data_o,
-        input  logic [3:0]       sdio_data_oen_i,
+        input  logic             sdio_clk_i       ,
+        input  logic             sdio_cmd_i       ,
+        output logic             sdio_cmd_o       ,
+        input  logic             sdio_cmd_oen_i   ,
+        input  logic [3:0]       sdio_data_i      ,
+        output logic [3:0]       sdio_data_o      ,
+        input  logic [3:0]       sdio_data_oen_i  ,
 
         // GPIOS
-        input  logic [31:0]      gpio_out_i           ,
-        output logic [31:0]      gpio_in_o            ,
-        input  logic [31:0]      gpio_dir_i           ,
-        input  logic [31:0][5:0] gpio_cfg_i           ,
+        input  logic [31:0]      gpio_out_i       ,
+        output logic [31:0]      gpio_in_o        ,
+        input  logic [31:0]      gpio_dir_i       ,
+        input  logic [31:0][5:0] gpio_cfg_i       ,
 
         // UART
-        input  logic             uart_tx_i            ,
-        output logic             uart_rx_o            ,
+        input  logic             uart_tx_i        ,
+        output logic             uart_rx_o        ,
 
         // I2C
-        input  logic [N_I2C-1:0] i2c_scl_out_i,
-        output logic [N_I2C-1:0] i2c_scl_in_o,
-        input  logic [N_I2C-1:0] i2c_scl_oe_i,
-        input  logic [N_I2C-1:0] i2c_sda_out_i,
-        output logic [N_I2C-1:0] i2c_sda_in_o,
-        input  logic [N_I2C-1:0] i2c_sda_oe_i,
+        input  logic [N_I2C-1:0] i2c_scl_out_i    ,
+        output logic [N_I2C-1:0] i2c_scl_in_o     ,
+        input  logic [N_I2C-1:0] i2c_scl_oe_i     ,
+        input  logic [N_I2C-1:0] i2c_sda_out_i    ,
+        output logic [N_I2C-1:0] i2c_sda_in_o     ,
+        input  logic [N_I2C-1:0] i2c_sda_oe_i     ,
 
         // I2S
-        output logic             i2s_slave_sd0_o      ,
-        output logic             i2s_slave_sd1_o      ,
-        output logic             i2s_slave_ws_o       ,
-        input  logic             i2s_slave_ws_i       ,
-        input  logic             i2s_slave_ws_oe      ,
-        output logic             i2s_slave_sck_o      ,
-        input  logic             i2s_slave_sck_i      ,
-        input  logic             i2s_slave_sck_oe     ,
+        output logic             i2s_slave_sd0_o  ,
+        output logic             i2s_slave_sd1_o  ,
+        output logic             i2s_slave_ws_o   ,
+        input  logic             i2s_slave_ws_i   ,
+        input  logic             i2s_slave_ws_oe  ,
+        output logic             i2s_slave_sck_o  ,
+        input  logic             i2s_slave_sck_i  ,
+        input  logic             i2s_slave_sck_oe ,
 
         // SPI MASTER
-        input  logic [N_SPI-1:0]      spi_clk_i,
-        input  logic [N_SPI-1:0][3:0] spi_csn_i,
-        input  logic [N_SPI-1:0][3:0] spi_oen_i,
-        input  logic [N_SPI-1:0][3:0] spi_sdo_i,
-        output logic [N_SPI-1:0][3:0] spi_sdi_o,
+        input  logic [N_SPI-1:0]      spi_clk_i   ,
+        input  logic [N_SPI-1:0][3:0] spi_csn_i   ,
+        input  logic [N_SPI-1:0][3:0] spi_oen_i   ,
+        input  logic [N_SPI-1:0][3:0] spi_sdo_i   ,
+        output logic [N_SPI-1:0][3:0] spi_sdi_o   ,
 
         // CAMERA INTERFACE
-        output logic             cam_pclk_o           ,
-        output logic [7:0]       cam_data_o           ,
-        output logic             cam_hsync_o          ,
-        output logic             cam_vsync_o          ,
+        output logic             cam_pclk_o       ,
+        output logic [7:0]       cam_data_o       ,
+        output logic             cam_hsync_o      ,
+        output logic             cam_vsync_o      ,
 
         // TIMER
-        input  logic [3:0]       timer0_i             ,
-        input  logic [3:0]       timer1_i             ,
-        input  logic [3:0]       timer2_i             ,
-        input  logic [3:0]       timer3_i             ,
+        input  logic [3:0]       timer0_i         ,
+        input  logic [3:0]       timer1_i         ,
+        input  logic [3:0]       timer2_i         ,
+        input  logic [3:0]       timer3_i         ,
 
         //********************************************************************//
         //*** PAD FRAME SIGNALS **********************************************//
@@ -129,12 +129,12 @@ module pad_control #(
         input logic              in_spim_csn0_i   ,
         input logic              in_spim_csn1_i   ,
         input logic              in_spim_sck_i    ,
-        input logic              in_sdio_clk_i        ,
-        input logic              in_sdio_cmd_i        ,
-        input logic              in_sdio_data0_i      ,
-        input logic              in_sdio_data1_i      ,
-        input logic              in_sdio_data2_i      ,
-        input logic              in_sdio_data3_i      ,
+        input logic              in_sdio_clk_i    ,
+        input logic              in_sdio_cmd_i    ,
+        input logic              in_sdio_data0_i  ,
+        input logic              in_sdio_data1_i  ,
+        input logic              in_sdio_data2_i  ,
+        input logic              in_sdio_data3_i  ,
         input logic              in_uart_rx_i     ,
         input logic              in_uart_tx_i     ,
         input logic              in_cam_pclk_i    ,
@@ -206,124 +206,123 @@ module pad_control #(
    /////////////////////////////////////////////////////////////////////////////////////////////
    // OUTPUT ENABLE
    /////////////////////////////////////////////////////////////////////////////////////////////
-   assign oe_spim_sdio0_o  = (pad_mux_i[0 ] == 2'b00) ? ~spi_oen_i[0][0]    : ((pad_mux_i[0 ] == 2'b01) ? gpio_dir_i[0 ] : ((pad_mux_i[0 ] == 2'b10) ? s_alt2        : s_alt3 ));
-   assign oe_spim_sdio1_o  = (pad_mux_i[1 ] == 2'b00) ? ~spi_oen_i[0][1]    : ((pad_mux_i[1 ] == 2'b01) ? gpio_dir_i[1 ] : ((pad_mux_i[1 ] == 2'b10) ? s_alt2        : s_alt3 ));
+   assign oe_spim_sdio0_o  = (pad_mux_i[0 ] == 2'b00) ? ~spi_oen_i[0][0]    : ((pad_mux_i[0 ] == 2'b01) ? gpio_dir_i[0 ] : ((pad_mux_i[0 ] == 2'b10) ? s_alt2          : s_alt3 ));
+   assign oe_spim_sdio1_o  = (pad_mux_i[1 ] == 2'b00) ? ~spi_oen_i[0][1]    : ((pad_mux_i[1 ] == 2'b01) ? gpio_dir_i[1 ] : ((pad_mux_i[1 ] == 2'b10) ? s_alt2          : s_alt3 ));
    assign oe_spim_sdio2_o  = (pad_mux_i[2 ] == 2'b00) ? ~spi_oen_i[0][2]    : ((pad_mux_i[2 ] == 2'b01) ? gpio_dir_i[2 ] : ((pad_mux_i[2 ] == 2'b10) ? i2c_sda_oe_i[1] : s_alt3 ));
    assign oe_spim_sdio3_o  = (pad_mux_i[3 ] == 2'b00) ? ~spi_oen_i[0][3]    : ((pad_mux_i[3 ] == 2'b01) ? gpio_dir_i[3 ] : ((pad_mux_i[3 ] == 2'b10) ? i2c_scl_oe_i[1] : s_alt3 ));
-   assign oe_spim_csn0_o   = (pad_mux_i[4 ] == 2'b00) ? 1'b1                : ((pad_mux_i[4 ] == 2'b01) ? gpio_dir_i[4 ] : ((pad_mux_i[4 ] == 2'b10) ? s_alt2        : s_alt3 ));
-   assign oe_spim_csn1_o   = (pad_mux_i[5 ] == 2'b00) ? 1'b1                : ((pad_mux_i[5 ] == 2'b01) ? gpio_dir_i[5 ] : ((pad_mux_i[5 ] == 2'b10) ? s_alt2        : s_alt3 ));
-   assign oe_spim_sck_o    = (pad_mux_i[6 ] == 2'b00) ? 1'b1                : ((pad_mux_i[6 ] == 2'b01) ? gpio_dir_i[6 ] : ((pad_mux_i[6 ] == 2'b10) ? s_alt2        : s_alt3 ));
+   assign oe_spim_csn0_o   = (pad_mux_i[4 ] == 2'b00) ? 1'b1                : ((pad_mux_i[4 ] == 2'b01) ? gpio_dir_i[4 ] : ((pad_mux_i[4 ] == 2'b10) ? s_alt2          : s_alt3 ));
+   assign oe_spim_csn1_o   = (pad_mux_i[5 ] == 2'b00) ? 1'b1                : ((pad_mux_i[5 ] == 2'b01) ? gpio_dir_i[5 ] : ((pad_mux_i[5 ] == 2'b10) ? s_alt2          : s_alt3 ));
+   assign oe_spim_sck_o    = (pad_mux_i[6 ] == 2'b00) ? 1'b1                : ((pad_mux_i[6 ] == 2'b01) ? gpio_dir_i[6 ] : ((pad_mux_i[6 ] == 2'b10) ? s_alt2          : s_alt3 ));
    assign oe_uart_rx_o     = (pad_mux_i[7 ] == 2'b00) ? 1'b0                : ((pad_mux_i[7 ] == 2'b01) ? gpio_dir_i[7 ] : ((pad_mux_i[7 ] == 2'b10) ? i2c_sda_oe_i[1] : s_alt3 ));
    assign oe_uart_tx_o     = (pad_mux_i[8 ] == 2'b00) ? 1'b1                : ((pad_mux_i[8 ] == 2'b01) ? gpio_dir_i[8 ] : ((pad_mux_i[8 ] == 2'b10) ? i2c_scl_oe_i[1] : s_alt3 ));
-   assign oe_cam_pclk_o    = (pad_mux_i[9 ] == 2'b00) ? 1'b0                : ((pad_mux_i[9 ] == 2'b01) ? gpio_dir_i[9 ] : ((pad_mux_i[9 ] == 2'b10) ? 1'b1          : s_alt3 ));
-   assign oe_cam_hsync_o   = (pad_mux_i[10] == 2'b00) ? 1'b0                : ((pad_mux_i[10] == 2'b01) ? gpio_dir_i[10] : ((pad_mux_i[10] == 2'b10) ? 1'b1          : s_alt3 ));
-   assign oe_cam_data0_o   = (pad_mux_i[11] == 2'b00) ? 1'b0                : ((pad_mux_i[11] == 2'b01) ? gpio_dir_i[11] : ((pad_mux_i[11] == 2'b10) ? 1'b1          : s_alt3 ));
-   assign oe_cam_data1_o   = (pad_mux_i[12] == 2'b00) ? 1'b0                : ((pad_mux_i[12] == 2'b01) ? gpio_dir_i[12] : ((pad_mux_i[12] == 2'b10) ? 1'b1          : s_alt3 ));
-   assign oe_cam_data2_o   = (pad_mux_i[13] == 2'b00) ? 1'b0                : ((pad_mux_i[13] == 2'b01) ? gpio_dir_i[13] : ((pad_mux_i[13] == 2'b10) ? 1'b1          : s_alt3 ));
-   assign oe_cam_data3_o   = (pad_mux_i[14] == 2'b00) ? 1'b0                : ((pad_mux_i[14] == 2'b01) ? gpio_dir_i[14] : ((pad_mux_i[14] == 2'b10) ? 1'b1          : s_alt3 ));
-   assign oe_cam_data4_o   = (pad_mux_i[15] == 2'b00) ? 1'b0                : ((pad_mux_i[15] == 2'b01) ? gpio_dir_i[15] : ((pad_mux_i[15] == 2'b10) ? 1'b1          : s_alt3 ));
-   assign oe_cam_data5_o   = (pad_mux_i[16] == 2'b00) ? 1'b0                : ((pad_mux_i[16] == 2'b01) ? gpio_dir_i[16] : ((pad_mux_i[16] == 2'b10) ? 1'b1          : s_alt3 ));
-   assign oe_cam_data6_o   = (pad_mux_i[17] == 2'b00) ? 1'b0                : ((pad_mux_i[17] == 2'b01) ? gpio_dir_i[17] : ((pad_mux_i[17] == 2'b10) ? 1'b1          : s_alt3 ));
-   assign oe_cam_data7_o   = (pad_mux_i[18] == 2'b00) ? 1'b0                : ((pad_mux_i[18] == 2'b01) ? gpio_dir_i[18] : ((pad_mux_i[18] == 2'b10) ? 1'b1          : s_alt3 ));
-   assign oe_cam_vsync_o   = (pad_mux_i[19] == 2'b00) ? 1'b0                : ((pad_mux_i[19] == 2'b01) ? gpio_dir_i[19] : ((pad_mux_i[19] == 2'b10) ? 1'b1          : s_alt3 ));
-   assign oe_sdio_clk_o    = (pad_mux_i[20] == 2'b00) ? 1'b1                : ((pad_mux_i[20] == 2'b01) ? gpio_dir_i[20] : ((pad_mux_i[20] == 2'b10) ? 1'b0          : s_alt3 ));
-   assign oe_sdio_cmd_o    = (pad_mux_i[21] == 2'b00) ? ~sdio_cmd_oen_i     : ((pad_mux_i[21] == 2'b01) ? gpio_dir_i[21] : ((pad_mux_i[21] == 2'b10) ? 1'b0          : s_alt3 ));
-   assign oe_sdio_data0_o  = (pad_mux_i[22] == 2'b00) ? ~sdio_data_oen_i[0] : ((pad_mux_i[22] == 2'b01) ? gpio_dir_i[22] : ((pad_mux_i[22] == 2'b10) ? 1'b0          : s_alt3 ));
-   assign oe_sdio_data1_o  = (pad_mux_i[23] == 2'b00) ? ~sdio_data_oen_i[1] : ((pad_mux_i[23] == 2'b01) ? gpio_dir_i[23] : ((pad_mux_i[23] == 2'b10) ? 1'b0          : s_alt3 ));
+   assign oe_cam_pclk_o    = (pad_mux_i[9 ] == 2'b00) ? 1'b0                : ((pad_mux_i[9 ] == 2'b01) ? gpio_dir_i[9 ] : ((pad_mux_i[9 ] == 2'b10) ? 1'b1            : s_alt3 ));
+   assign oe_cam_hsync_o   = (pad_mux_i[10] == 2'b00) ? 1'b0                : ((pad_mux_i[10] == 2'b01) ? gpio_dir_i[10] : ((pad_mux_i[10] == 2'b10) ? 1'b1            : s_alt3 ));
+   assign oe_cam_data0_o   = (pad_mux_i[11] == 2'b00) ? 1'b0                : ((pad_mux_i[11] == 2'b01) ? gpio_dir_i[11] : ((pad_mux_i[11] == 2'b10) ? 1'b1            : s_alt3 ));
+   assign oe_cam_data1_o   = (pad_mux_i[12] == 2'b00) ? 1'b0                : ((pad_mux_i[12] == 2'b01) ? gpio_dir_i[12] : ((pad_mux_i[12] == 2'b10) ? 1'b1            : s_alt3 ));
+   assign oe_cam_data2_o   = (pad_mux_i[13] == 2'b00) ? 1'b0                : ((pad_mux_i[13] == 2'b01) ? gpio_dir_i[13] : ((pad_mux_i[13] == 2'b10) ? 1'b1            : s_alt3 ));
+   assign oe_cam_data3_o   = (pad_mux_i[14] == 2'b00) ? 1'b0                : ((pad_mux_i[14] == 2'b01) ? gpio_dir_i[14] : ((pad_mux_i[14] == 2'b10) ? 1'b1            : s_alt3 ));
+   assign oe_cam_data4_o   = (pad_mux_i[15] == 2'b00) ? 1'b0                : ((pad_mux_i[15] == 2'b01) ? gpio_dir_i[15] : ((pad_mux_i[15] == 2'b10) ? 1'b1            : s_alt3 ));
+   assign oe_cam_data5_o   = (pad_mux_i[16] == 2'b00) ? 1'b0                : ((pad_mux_i[16] == 2'b01) ? gpio_dir_i[16] : ((pad_mux_i[16] == 2'b10) ? 1'b1            : s_alt3 ));
+   assign oe_cam_data6_o   = (pad_mux_i[17] == 2'b00) ? 1'b0                : ((pad_mux_i[17] == 2'b01) ? gpio_dir_i[17] : ((pad_mux_i[17] == 2'b10) ? 1'b1            : s_alt3 ));
+   assign oe_cam_data7_o   = (pad_mux_i[18] == 2'b00) ? 1'b0                : ((pad_mux_i[18] == 2'b01) ? gpio_dir_i[18] : ((pad_mux_i[18] == 2'b10) ? 1'b1            : s_alt3 ));
+   assign oe_cam_vsync_o   = (pad_mux_i[19] == 2'b00) ? 1'b0                : ((pad_mux_i[19] == 2'b01) ? gpio_dir_i[19] : ((pad_mux_i[19] == 2'b10) ? 1'b1            : s_alt3 ));
+   assign oe_sdio_clk_o    = (pad_mux_i[20] == 2'b00) ? 1'b1                : ((pad_mux_i[20] == 2'b01) ? gpio_dir_i[20] : ((pad_mux_i[20] == 2'b10) ? 1'b0            : s_alt3 ));
+   assign oe_sdio_cmd_o    = (pad_mux_i[21] == 2'b00) ? ~sdio_cmd_oen_i     : ((pad_mux_i[21] == 2'b01) ? gpio_dir_i[21] : ((pad_mux_i[21] == 2'b10) ? 1'b0            : s_alt3 ));
+   assign oe_sdio_data0_o  = (pad_mux_i[22] == 2'b00) ? ~sdio_data_oen_i[0] : ((pad_mux_i[22] == 2'b01) ? gpio_dir_i[22] : ((pad_mux_i[22] == 2'b10) ? 1'b0            : s_alt3 ));
+   assign oe_sdio_data1_o  = (pad_mux_i[23] == 2'b00) ? ~sdio_data_oen_i[1] : ((pad_mux_i[23] == 2'b01) ? gpio_dir_i[23] : ((pad_mux_i[23] == 2'b10) ? 1'b0            : s_alt3 ));
    assign oe_sdio_data2_o  = (pad_mux_i[24] == 2'b00) ? ~sdio_data_oen_i[2] : ((pad_mux_i[24] == 2'b01) ? gpio_dir_i[24] : ((pad_mux_i[24] == 2'b10) ? i2c_sda_oe_i[1] : s_alt3 ));
    assign oe_sdio_data3_o  = (pad_mux_i[25] == 2'b00) ? ~sdio_data_oen_i[3] : ((pad_mux_i[25] == 2'b01) ? gpio_dir_i[25] : ((pad_mux_i[25] == 2'b10) ? i2c_scl_oe_i[1] : s_alt3 ));
-   assign oe_i2c0_sda_o    = (pad_mux_i[33] == 2'b00) ? i2c_sda_oe_i[0]     : ((pad_mux_i[33] == 2'b01) ? gpio_dir_i[26] : ((pad_mux_i[33] == 2'b10) ? s_alt2        : s_alt3 ));
-   assign oe_i2c0_scl_o    = (pad_mux_i[34] == 2'b00) ? i2c_scl_oe_i[0]     : ((pad_mux_i[34] == 2'b01) ? gpio_dir_i[27] : ((pad_mux_i[34] == 2'b10) ? s_alt2        : s_alt3 ));
-   assign oe_i2s0_sck_o    = (pad_mux_i[35] == 2'b00) ? i2s_slave_sck_oe    : ((pad_mux_i[35] == 2'b01) ? gpio_dir_i[28] : ((pad_mux_i[35] == 2'b10) ? s_alt2        : s_alt3 ));
-   assign oe_i2s0_ws_o     = (pad_mux_i[36] == 2'b00) ? i2s_slave_ws_oe     : ((pad_mux_i[36] == 2'b01) ? gpio_dir_i[29] : ((pad_mux_i[36] == 2'b10) ? s_alt2        : s_alt3 ));
-   assign oe_i2s0_sdi_o    = (pad_mux_i[37] == 2'b00) ? 1'b0                : ((pad_mux_i[37] == 2'b01) ? gpio_dir_i[30] : ((pad_mux_i[37] == 2'b10) ? s_alt2        : s_alt3 ));
-   assign oe_i2s1_sdi_o    = (pad_mux_i[38] == 2'b00) ? 1'b0                : ((pad_mux_i[38] == 2'b01) ? gpio_dir_i[31] : ((pad_mux_i[38] == 2'b10) ? s_alt2        : s_alt3 ));
+   assign oe_i2c0_sda_o    = (pad_mux_i[33] == 2'b00) ? i2c_sda_oe_i[0]     : ((pad_mux_i[33] == 2'b01) ? gpio_dir_i[26] : ((pad_mux_i[33] == 2'b10) ? s_alt2          : s_alt3 ));
+   assign oe_i2c0_scl_o    = (pad_mux_i[34] == 2'b00) ? i2c_scl_oe_i[0]     : ((pad_mux_i[34] == 2'b01) ? gpio_dir_i[27] : ((pad_mux_i[34] == 2'b10) ? s_alt2          : s_alt3 ));
+   assign oe_i2s0_sck_o    = (pad_mux_i[35] == 2'b00) ? i2s_slave_sck_oe    : ((pad_mux_i[35] == 2'b01) ? gpio_dir_i[28] : ((pad_mux_i[35] == 2'b10) ? s_alt2          : s_alt3 ));
+   assign oe_i2s0_ws_o     = (pad_mux_i[36] == 2'b00) ? i2s_slave_ws_oe     : ((pad_mux_i[36] == 2'b01) ? gpio_dir_i[29] : ((pad_mux_i[36] == 2'b10) ? s_alt2          : s_alt3 ));
+   assign oe_i2s0_sdi_o    = (pad_mux_i[37] == 2'b00) ? 1'b0                : ((pad_mux_i[37] == 2'b01) ? gpio_dir_i[30] : ((pad_mux_i[37] == 2'b10) ? s_alt2          : s_alt3 ));
+   assign oe_i2s1_sdi_o    = (pad_mux_i[38] == 2'b00) ? 1'b0                : ((pad_mux_i[38] == 2'b01) ? gpio_dir_i[31] : ((pad_mux_i[38] == 2'b10) ? s_alt2          : s_alt3 ));
 
    /////////////////////////////////////////////////////////////////////////////////////////////
    // DATA OUTPUT
    /////////////////////////////////////////////////////////////////////////////////////////////
-   assign out_spim_sdio0_o = (pad_mux_i[0 ] == 2'b00) ? spi_sdo_i[0][0]    : ((pad_mux_i[0 ] == 2'b01) ? gpio_out_i[0 ] : ((pad_mux_i[0 ] == 2'b10) ? s_alt2         : s_alt3 ));
-   assign out_spim_sdio1_o = (pad_mux_i[1 ] == 2'b00) ? spi_sdo_i[0][1]    : ((pad_mux_i[1 ] == 2'b01) ? gpio_out_i[1 ] : ((pad_mux_i[1 ] == 2'b10) ? s_alt2         : s_alt3 ));
+   assign out_spim_sdio0_o = (pad_mux_i[0 ] == 2'b00) ? spi_sdo_i[0][0]    : ((pad_mux_i[0 ] == 2'b01) ? gpio_out_i[0 ] : ((pad_mux_i[0 ] == 2'b10) ? s_alt2           : s_alt3 ));
+   assign out_spim_sdio1_o = (pad_mux_i[1 ] == 2'b00) ? spi_sdo_i[0][1]    : ((pad_mux_i[1 ] == 2'b01) ? gpio_out_i[1 ] : ((pad_mux_i[1 ] == 2'b10) ? s_alt2           : s_alt3 ));
    assign out_spim_sdio2_o = (pad_mux_i[2 ] == 2'b00) ? spi_sdo_i[0][2]    : ((pad_mux_i[2 ] == 2'b01) ? gpio_out_i[2 ] : ((pad_mux_i[2 ] == 2'b10) ? i2c_sda_out_i[1] : s_alt3 ));
    assign out_spim_sdio3_o = (pad_mux_i[3 ] == 2'b00) ? spi_sdo_i[0][3]    : ((pad_mux_i[3 ] == 2'b01) ? gpio_out_i[3 ] : ((pad_mux_i[3 ] == 2'b10) ? i2c_scl_out_i[1] : s_alt3 ));
-   assign out_spim_csn0_o  = (pad_mux_i[4 ] == 2'b00) ? spi_csn_i[0][0]    : ((pad_mux_i[4 ] == 2'b01) ? gpio_out_i[4 ] : ((pad_mux_i[4 ] == 2'b10) ? s_alt2         : s_alt3 ));
-   assign out_spim_csn1_o  = (pad_mux_i[5 ] == 2'b00) ? spi_csn_i[0][1]    : ((pad_mux_i[5 ] == 2'b01) ? gpio_out_i[5 ] : ((pad_mux_i[5 ] == 2'b10) ? s_alt2         : s_alt3 ));
-   assign out_spim_sck_o   = (pad_mux_i[6 ] == 2'b00) ? spi_clk_i[0]       : ((pad_mux_i[6 ] == 2'b01) ? gpio_out_i[6 ] : ((pad_mux_i[6 ] == 2'b10) ? s_alt2         : s_alt3 ));
+   assign out_spim_csn0_o  = (pad_mux_i[4 ] == 2'b00) ? spi_csn_i[0][0]    : ((pad_mux_i[4 ] == 2'b01) ? gpio_out_i[4 ] : ((pad_mux_i[4 ] == 2'b10) ? s_alt2           : s_alt3 ));
+   assign out_spim_csn1_o  = (pad_mux_i[5 ] == 2'b00) ? spi_csn_i[0][1]    : ((pad_mux_i[5 ] == 2'b01) ? gpio_out_i[5 ] : ((pad_mux_i[5 ] == 2'b10) ? s_alt2           : s_alt3 ));
+   assign out_spim_sck_o   = (pad_mux_i[6 ] == 2'b00) ? spi_clk_i[0]       : ((pad_mux_i[6 ] == 2'b01) ? gpio_out_i[6 ] : ((pad_mux_i[6 ] == 2'b10) ? s_alt2           : s_alt3 ));
    assign out_uart_rx_o    = (pad_mux_i[7 ] == 2'b00) ? 1'b0               : ((pad_mux_i[7 ] == 2'b01) ? gpio_out_i[7 ] : ((pad_mux_i[7 ] == 2'b10) ? i2c_sda_out_i[1] : s_alt3 ));
    assign out_uart_tx_o    = (pad_mux_i[8 ] == 2'b00) ? uart_tx_i          : ((pad_mux_i[8 ] == 2'b01) ? gpio_out_i[8 ] : ((pad_mux_i[8 ] == 2'b10) ? i2c_scl_out_i[1] : s_alt3 ));
-   assign out_cam_pclk_o   = (pad_mux_i[9 ] == 2'b00) ? 1'b0               : ((pad_mux_i[9 ] == 2'b01) ? gpio_out_i[9 ] : ((pad_mux_i[9 ] == 2'b10) ? timer1_i[0]    : s_alt3 ));
-   assign out_cam_hsync_o  = (pad_mux_i[10] == 2'b00) ? 1'b0               : ((pad_mux_i[10] == 2'b01) ? gpio_out_i[10] : ((pad_mux_i[10] == 2'b10) ? timer1_i[1]    : s_alt3 ));
-   assign out_cam_data0_o  = (pad_mux_i[11] == 2'b00) ? 1'b0               : ((pad_mux_i[11] == 2'b01) ? gpio_out_i[11] : ((pad_mux_i[11] == 2'b10) ? timer1_i[2]    : s_alt3 ));
-   assign out_cam_data1_o  = (pad_mux_i[12] == 2'b00) ? 1'b0               : ((pad_mux_i[12] == 2'b01) ? gpio_out_i[12] : ((pad_mux_i[12] == 2'b10) ? timer1_i[3]    : s_alt3 ));
-   assign out_cam_data2_o  = (pad_mux_i[13] == 2'b00) ? 1'b0               : ((pad_mux_i[13] == 2'b01) ? gpio_out_i[13] : ((pad_mux_i[13] == 2'b10) ? timer2_i[0]    : s_alt3 ));
-   assign out_cam_data3_o  = (pad_mux_i[14] == 2'b00) ? 1'b0               : ((pad_mux_i[14] == 2'b01) ? gpio_out_i[14] : ((pad_mux_i[14] == 2'b10) ? timer2_i[1]    : s_alt3 ));
-   assign out_cam_data4_o  = (pad_mux_i[15] == 2'b00) ? 1'b0               : ((pad_mux_i[15] == 2'b01) ? gpio_out_i[15] : ((pad_mux_i[15] == 2'b10) ? timer2_i[2]    : s_alt3 ));
-   assign out_cam_data5_o  = (pad_mux_i[16] == 2'b00) ? 1'b0               : ((pad_mux_i[16] == 2'b01) ? gpio_out_i[16] : ((pad_mux_i[16] == 2'b10) ? timer2_i[3]    : s_alt3 ));
-   assign out_cam_data6_o  = (pad_mux_i[17] == 2'b00) ? 1'b0               : ((pad_mux_i[17] == 2'b01) ? gpio_out_i[17] : ((pad_mux_i[17] == 2'b10) ? timer3_i[0]    : s_alt3 ));
-   assign out_cam_data7_o  = (pad_mux_i[18] == 2'b00) ? 1'b0               : ((pad_mux_i[18] == 2'b01) ? gpio_out_i[18] : ((pad_mux_i[18] == 2'b10) ? timer3_i[1]    : s_alt3 ));
-   assign out_cam_vsync_o  = (pad_mux_i[19] == 2'b00) ? 1'b0               : ((pad_mux_i[19] == 2'b01) ? gpio_out_i[19] : ((pad_mux_i[19] == 2'b10) ? timer3_i[2]    : s_alt3 ));
-   assign out_sdio_clk_o   = (pad_mux_i[20] == 2'b00) ? sdio_clk_i         : ((pad_mux_i[20] == 2'b01) ? gpio_out_i[20] : ((pad_mux_i[20] == 2'b10) ? s_alt2         : s_alt3 ));
-   assign out_sdio_cmd_o   = (pad_mux_i[21] == 2'b00) ? sdio_cmd_i         : ((pad_mux_i[21] == 2'b01) ? gpio_out_i[21] : ((pad_mux_i[21] == 2'b10) ? s_alt2         : s_alt3 ));
-   assign out_sdio_data0_o = (pad_mux_i[22] == 2'b00) ? sdio_data_i[0]     : ((pad_mux_i[22] == 2'b01) ? gpio_out_i[22] : ((pad_mux_i[22] == 2'b10) ? s_alt2         : s_alt3 ));
-   assign out_sdio_data1_o = (pad_mux_i[23] == 2'b00) ? sdio_data_i[1]     : ((pad_mux_i[23] == 2'b01) ? gpio_out_i[23] : ((pad_mux_i[23] == 2'b10) ? s_alt2         : s_alt3 ));
+   assign out_cam_pclk_o   = (pad_mux_i[9 ] == 2'b00) ? 1'b0               : ((pad_mux_i[9 ] == 2'b01) ? gpio_out_i[9 ] : ((pad_mux_i[9 ] == 2'b10) ? timer1_i[0]      : s_alt3 ));
+   assign out_cam_hsync_o  = (pad_mux_i[10] == 2'b00) ? 1'b0               : ((pad_mux_i[10] == 2'b01) ? gpio_out_i[10] : ((pad_mux_i[10] == 2'b10) ? timer1_i[1]      : s_alt3 ));
+   assign out_cam_data0_o  = (pad_mux_i[11] == 2'b00) ? 1'b0               : ((pad_mux_i[11] == 2'b01) ? gpio_out_i[11] : ((pad_mux_i[11] == 2'b10) ? timer1_i[2]      : s_alt3 ));
+   assign out_cam_data1_o  = (pad_mux_i[12] == 2'b00) ? 1'b0               : ((pad_mux_i[12] == 2'b01) ? gpio_out_i[12] : ((pad_mux_i[12] == 2'b10) ? timer1_i[3]      : s_alt3 ));
+   assign out_cam_data2_o  = (pad_mux_i[13] == 2'b00) ? 1'b0               : ((pad_mux_i[13] == 2'b01) ? gpio_out_i[13] : ((pad_mux_i[13] == 2'b10) ? timer2_i[0]      : s_alt3 ));
+   assign out_cam_data3_o  = (pad_mux_i[14] == 2'b00) ? 1'b0               : ((pad_mux_i[14] == 2'b01) ? gpio_out_i[14] : ((pad_mux_i[14] == 2'b10) ? timer2_i[1]      : s_alt3 ));
+   assign out_cam_data4_o  = (pad_mux_i[15] == 2'b00) ? 1'b0               : ((pad_mux_i[15] == 2'b01) ? gpio_out_i[15] : ((pad_mux_i[15] == 2'b10) ? timer2_i[2]      : s_alt3 ));
+   assign out_cam_data5_o  = (pad_mux_i[16] == 2'b00) ? 1'b0               : ((pad_mux_i[16] == 2'b01) ? gpio_out_i[16] : ((pad_mux_i[16] == 2'b10) ? timer2_i[3]      : s_alt3 ));
+   assign out_cam_data6_o  = (pad_mux_i[17] == 2'b00) ? 1'b0               : ((pad_mux_i[17] == 2'b01) ? gpio_out_i[17] : ((pad_mux_i[17] == 2'b10) ? timer3_i[0]      : s_alt3 ));
+   assign out_cam_data7_o  = (pad_mux_i[18] == 2'b00) ? 1'b0               : ((pad_mux_i[18] == 2'b01) ? gpio_out_i[18] : ((pad_mux_i[18] == 2'b10) ? timer3_i[1]      : s_alt3 ));
+   assign out_cam_vsync_o  = (pad_mux_i[19] == 2'b00) ? 1'b0               : ((pad_mux_i[19] == 2'b01) ? gpio_out_i[19] : ((pad_mux_i[19] == 2'b10) ? timer3_i[2]      : s_alt3 ));
+   assign out_sdio_clk_o   = (pad_mux_i[20] == 2'b00) ? sdio_clk_i         : ((pad_mux_i[20] == 2'b01) ? gpio_out_i[20] : ((pad_mux_i[20] == 2'b10) ? s_alt2           : s_alt3 ));
+   assign out_sdio_cmd_o   = (pad_mux_i[21] == 2'b00) ? sdio_cmd_i         : ((pad_mux_i[21] == 2'b01) ? gpio_out_i[21] : ((pad_mux_i[21] == 2'b10) ? s_alt2           : s_alt3 ));
+   assign out_sdio_data0_o = (pad_mux_i[22] == 2'b00) ? sdio_data_i[0]     : ((pad_mux_i[22] == 2'b01) ? gpio_out_i[22] : ((pad_mux_i[22] == 2'b10) ? s_alt2           : s_alt3 ));
+   assign out_sdio_data1_o = (pad_mux_i[23] == 2'b00) ? sdio_data_i[1]     : ((pad_mux_i[23] == 2'b01) ? gpio_out_i[23] : ((pad_mux_i[23] == 2'b10) ? s_alt2           : s_alt3 ));
    assign out_sdio_data2_o = (pad_mux_i[24] == 2'b00) ? sdio_data_i[2]     : ((pad_mux_i[24] == 2'b01) ? gpio_out_i[24] : ((pad_mux_i[24] == 2'b10) ? i2c_sda_out_i[1] : s_alt3 ));
    assign out_sdio_data3_o = (pad_mux_i[25] == 2'b00) ? sdio_data_i[3]     : ((pad_mux_i[25] == 2'b01) ? gpio_out_i[25] : ((pad_mux_i[25] == 2'b10) ? i2c_scl_out_i[1] : s_alt3 ));
-   assign out_i2c0_sda_o   = (pad_mux_i[33] == 2'b00) ? i2c_sda_out_i[0]   : ((pad_mux_i[33] == 2'b01) ? gpio_out_i[26] : ((pad_mux_i[33] == 2'b10) ? s_alt2         : s_alt3 ));
-   assign out_i2c0_scl_o   = (pad_mux_i[34] == 2'b00) ? i2c_scl_out_i[0]   : ((pad_mux_i[34] == 2'b01) ? gpio_out_i[27] : ((pad_mux_i[34] == 2'b10) ? s_alt2         : s_alt3 ));
-   assign out_i2s0_sck_o   = (pad_mux_i[35] == 2'b00) ? i2s_slave_sck_i    : ((pad_mux_i[35] == 2'b01) ? gpio_out_i[28] : ((pad_mux_i[35] == 2'b10) ? s_alt2         : s_alt3 ));
-   assign out_i2s0_ws_o    = (pad_mux_i[36] == 2'b00) ? i2s_slave_ws_i     : ((pad_mux_i[36] == 2'b01) ? gpio_out_i[29] : ((pad_mux_i[36] == 2'b10) ? s_alt2         : s_alt3 ));
-   assign out_i2s0_sdi_o   = (pad_mux_i[37] == 2'b00) ? 1'b0               : ((pad_mux_i[37] == 2'b01) ? gpio_out_i[30] : ((pad_mux_i[37] == 2'b10) ? s_alt2         : s_alt3 ));
-   assign out_i2s1_sdi_o   = (pad_mux_i[38] == 2'b00) ? 1'b0               : ((pad_mux_i[38] == 2'b01) ? gpio_out_i[31] : ((pad_mux_i[38] == 2'b10) ? s_alt2         : s_alt3 ));
+   assign out_i2c0_sda_o   = (pad_mux_i[33] == 2'b00) ? i2c_sda_out_i[0]   : ((pad_mux_i[33] == 2'b01) ? gpio_out_i[26] : ((pad_mux_i[33] == 2'b10) ? s_alt2           : s_alt3 ));
+   assign out_i2c0_scl_o   = (pad_mux_i[34] == 2'b00) ? i2c_scl_out_i[0]   : ((pad_mux_i[34] == 2'b01) ? gpio_out_i[27] : ((pad_mux_i[34] == 2'b10) ? s_alt2           : s_alt3 ));
+   assign out_i2s0_sck_o   = (pad_mux_i[35] == 2'b00) ? i2s_slave_sck_i    : ((pad_mux_i[35] == 2'b01) ? gpio_out_i[28] : ((pad_mux_i[35] == 2'b10) ? s_alt2           : s_alt3 ));
+   assign out_i2s0_ws_o    = (pad_mux_i[36] == 2'b00) ? i2s_slave_ws_i     : ((pad_mux_i[36] == 2'b01) ? gpio_out_i[29] : ((pad_mux_i[36] == 2'b10) ? s_alt2           : s_alt3 ));
+   assign out_i2s0_sdi_o   = (pad_mux_i[37] == 2'b00) ? 1'b0               : ((pad_mux_i[37] == 2'b01) ? gpio_out_i[30] : ((pad_mux_i[37] == 2'b10) ? s_alt2           : s_alt3 ));
+   assign out_i2s1_sdi_o   = (pad_mux_i[38] == 2'b00) ? 1'b0               : ((pad_mux_i[38] == 2'b01) ? gpio_out_i[31] : ((pad_mux_i[38] == 2'b10) ? s_alt2           : s_alt3 ));
 
    /////////////////////////////////////////////////////////////////////////////////////////////
    // DATA INPUT
    /////////////////////////////////////////////////////////////////////////////////////////////
    //    SPI MASTER1
    // assign spi_master1_sdi_o = (pad_mux_i[0]  == 2'b00) ? in_rf_miso_i: (pad_mux_i[40] == 2'b00) ? in_spim1_miso_i : 1'b0;
-   // assign spi_sdi_o[1] = 1'b0;
 
-   assign sdio_cmd_o     = (pad_mux_i[21] == 2'b00) ? in_sdio_cmd_i   : 1'b0;
-   assign sdio_data_o[0] = (pad_mux_i[22] == 2'b00) ? in_sdio_data0_i : 1'b0;
-   assign sdio_data_o[1] = (pad_mux_i[23] == 2'b00) ? in_sdio_data1_i : 1'b0;
-   assign sdio_data_o[2] = (pad_mux_i[24] == 2'b00) ? in_sdio_data2_i : 1'b0;
-   assign sdio_data_o[3] = (pad_mux_i[25] == 2'b00) ? in_sdio_data3_i : 1'b0;
+   assign sdio_cmd_o      = (pad_mux_i[21] == 2'b00) ? in_sdio_cmd_i    : 1'b0;
+   assign sdio_data_o[0]  = (pad_mux_i[22] == 2'b00) ? in_sdio_data0_i  : 1'b0;
+   assign sdio_data_o[1]  = (pad_mux_i[23] == 2'b00) ? in_sdio_data1_i  : 1'b0;
+   assign sdio_data_o[2]  = (pad_mux_i[24] == 2'b00) ? in_sdio_data2_i  : 1'b0;
+   assign sdio_data_o[3]  = (pad_mux_i[25] == 2'b00) ? in_sdio_data3_i  : 1'b0;
 
    //    CAMERA
-   assign cam_pclk_o    = (pad_mux_i[ 9] == 2'b00) ? in_cam_pclk_i  : 1'b0;
-   assign cam_hsync_o   = (pad_mux_i[10] == 2'b00) ? in_cam_hsync_i : 1'b0;
-   assign cam_data_o[0] = (pad_mux_i[11] == 2'b00) ? in_cam_data0_i : 1'b0;
-   assign cam_data_o[1] = (pad_mux_i[12] == 2'b00) ? in_cam_data1_i : 1'b0;
-   assign cam_data_o[2] = (pad_mux_i[13] == 2'b00) ? in_cam_data2_i : 1'b0;
-   assign cam_data_o[3] = (pad_mux_i[14] == 2'b00) ? in_cam_data3_i : 1'b0;
-   assign cam_data_o[4] = (pad_mux_i[15] == 2'b00) ? in_cam_data4_i : 1'b0;
-   assign cam_data_o[5] = (pad_mux_i[16] == 2'b00) ? in_cam_data5_i : 1'b0;
-   assign cam_data_o[6] = (pad_mux_i[17] == 2'b00) ? in_cam_data6_i : 1'b0;
-   assign cam_data_o[7] = (pad_mux_i[18] == 2'b00) ? in_cam_data7_i : 1'b0;
-   assign cam_vsync_o   = (pad_mux_i[19] == 2'b00) ? in_cam_vsync_i : 1'b0;
+   assign cam_pclk_o      = (pad_mux_i[ 9] == 2'b00) ? in_cam_pclk_i    : 1'b0;
+   assign cam_hsync_o     = (pad_mux_i[10] == 2'b00) ? in_cam_hsync_i   : 1'b0;
+   assign cam_data_o[0]   = (pad_mux_i[11] == 2'b00) ? in_cam_data0_i   : 1'b0;
+   assign cam_data_o[1]   = (pad_mux_i[12] == 2'b00) ? in_cam_data1_i   : 1'b0;
+   assign cam_data_o[2]   = (pad_mux_i[13] == 2'b00) ? in_cam_data2_i   : 1'b0;
+   assign cam_data_o[3]   = (pad_mux_i[14] == 2'b00) ? in_cam_data3_i   : 1'b0;
+   assign cam_data_o[4]   = (pad_mux_i[15] == 2'b00) ? in_cam_data4_i   : 1'b0;
+   assign cam_data_o[5]   = (pad_mux_i[16] == 2'b00) ? in_cam_data5_i   : 1'b0;
+   assign cam_data_o[6]   = (pad_mux_i[17] == 2'b00) ? in_cam_data6_i   : 1'b0;
+   assign cam_data_o[7]   = (pad_mux_i[18] == 2'b00) ? in_cam_data7_i   : 1'b0;
+   assign cam_vsync_o     = (pad_mux_i[19] == 2'b00) ? in_cam_vsync_i   : 1'b0;
 
    //    I2C1
-   assign i2c_sda_in_o[1] = (pad_mux_i[2] == 2'b10) ? in_spim_sdio2_i : (pad_mux_i[7] == 2'b10) ? in_uart_rx_i : (pad_mux_i[24] == 2'b10) ? in_sdio_data2_i: 1'b1 ;
-   assign i2c_scl_in_o[1] = (pad_mux_i[3] == 2'b10) ? in_spim_sdio3_i : (pad_mux_i[8] == 2'b10) ? in_uart_tx_i : (pad_mux_i[25] == 2'b10) ? in_sdio_data3_i: 1'b1 ;
+   assign i2c_sda_in_o[1] = (pad_mux_i[2]  == 2'b10) ? in_spim_sdio2_i  : (pad_mux_i[7] == 2'b10)  ? in_uart_rx_i  : (pad_mux_i[24] == 2'b10) ? in_sdio_data2_i : 1'b1 ;
+   assign i2c_scl_in_o[1] = (pad_mux_i[3]  == 2'b10) ? in_spim_sdio3_i  : (pad_mux_i[8] == 2'b10)  ? in_uart_tx_i  : (pad_mux_i[25] == 2'b10) ? in_sdio_data3_i : 1'b1 ;
 
-   assign i2s_slave_sd1_o  = (pad_mux_i[29] == 2'b00) ? in_i2s1_sdi_i : (pad_mux_i[27] == 2'b11) ? in_i2s1_sdi_i : 1'b0;
+   assign i2s_slave_sd1_o = (pad_mux_i[29] == 2'b00) ? in_i2s1_sdi_i    : (pad_mux_i[27] == 2'b11) ? in_i2s1_sdi_i : 1'b0;
 
    //    UART
-   assign uart_rx_o     = (pad_mux_i[38] == 2'b00) ? in_uart_rx_i : 1'b1;
+   assign uart_rx_o       = (pad_mux_i[38] == 2'b00) ? in_uart_rx_i     : 1'b1;
 
    //    SPI
-   assign spi_sdi_o[0][0] = (pad_mux_i[33] == 2'b00) ? in_spim_sdio0_i : 1'b0;
-   assign spi_sdi_o[0][1] = (pad_mux_i[34] == 2'b00) ? in_spim_sdio1_i : 1'b0;
-   assign spi_sdi_o[0][2] = (pad_mux_i[35] == 2'b00) ? in_spim_sdio2_i : 1'b0;
-   assign spi_sdi_o[0][3] = (pad_mux_i[36] == 2'b00) ? in_spim_sdio3_i : 1'b0;
+   assign spi_sdi_o[0][0] = (pad_mux_i[33] == 2'b00) ? in_spim_sdio0_i  : 1'b0;
+   assign spi_sdi_o[0][1] = (pad_mux_i[34] == 2'b00) ? in_spim_sdio1_i  : 1'b0;
+   assign spi_sdi_o[0][2] = (pad_mux_i[35] == 2'b00) ? in_spim_sdio2_i  : 1'b0;
+   assign spi_sdi_o[0][3] = (pad_mux_i[36] == 2'b00) ? in_spim_sdio3_i  : 1'b0;
 
    //    I2C0
-   assign i2c_sda_in_o[0]      = (pad_mux_i[43] == 2'b00) ? in_i2c0_sda_i : 1'b1;
-   assign i2c_scl_in_o[0]      = (pad_mux_i[44] == 2'b00) ? in_i2c0_scl_i : 1'b1;
+   assign i2c_sda_in_o[0] = (pad_mux_i[43] == 2'b00) ? in_i2c0_sda_i    : 1'b1;
+   assign i2c_scl_in_o[0] = (pad_mux_i[44] == 2'b00) ? in_i2c0_scl_i    : 1'b1;
 
 
-   assign i2s_slave_sck_o       = (pad_mux_i[45] == 2'b00) ? in_i2s0_sck_i : 1'b0;
-   assign i2s_slave_ws_o        = (pad_mux_i[46] == 2'b00) ? in_i2s0_ws_i  : 1'b0;
-   assign i2s_slave_sd0_o       = (pad_mux_i[47] == 2'b00) ? in_i2s0_sdi_i : 1'b0;
+   assign i2s_slave_sck_o = (pad_mux_i[45] == 2'b00) ? in_i2s0_sck_i    : 1'b0;
+   assign i2s_slave_ws_o  = (pad_mux_i[46] == 2'b00) ? in_i2s0_ws_i     : 1'b0;
+   assign i2s_slave_sd0_o = (pad_mux_i[47] == 2'b00) ? in_i2s0_sdi_i    : 1'b0;
 
    //    GPIO
    assign gpio_in_o[0]  = (pad_mux_i[0]  == 2'b01) ? in_spim_sdio0_i : 1'b0 ;

--- a/rtl/pulp/pad_control.sv
+++ b/rtl/pulp/pad_control.sv
@@ -13,8 +13,11 @@
 `define SPI_QUAD_TX 2'b10
 `define SPI_QUAD_RX 2'b11
 
-module pad_control
-    (
+module pad_control #(
+    parameter int unsigned N_UART = 1,
+    parameter int unsigned N_SPI = 1,
+    parameter int unsigned N_I2C = 2
+) (
 
         //********************************************************************//
         //*** PERIPHERALS SIGNALS ********************************************//
@@ -43,21 +46,13 @@ module pad_control
         input  logic             uart_tx_i            ,
         output logic             uart_rx_o            ,
 
-        // I2C0
-        input  logic             i2c0_scl_out_i       ,
-        output logic             i2c0_scl_in_o        ,
-        input  logic             i2c0_scl_oe_i        ,
-        input  logic             i2c0_sda_out_i       ,
-        output logic             i2c0_sda_in_o        ,
-        input  logic             i2c0_sda_oe_i        ,
-
-        // I2C1
-        input  logic             i2c1_scl_out_i       ,
-        output logic             i2c1_scl_in_o        ,
-        input  logic             i2c1_scl_oe_i        ,
-        input  logic             i2c1_sda_out_i       ,
-        output logic             i2c1_sda_in_o        ,
-        input  logic             i2c1_sda_oe_i        ,
+        // I2C
+        input  logic [N_I2C-1:0] i2c_scl_out_i,
+        output logic [N_I2C-1:0] i2c_scl_in_o,
+        input  logic [N_I2C-1:0] i2c_scl_oe_i,
+        input  logic [N_I2C-1:0] i2c_sda_out_i,
+        output logic [N_I2C-1:0] i2c_sda_in_o,
+        input  logic [N_I2C-1:0] i2c_sda_oe_i,
 
         // I2S
         output logic             i2s_slave_sd0_o      ,
@@ -70,21 +65,11 @@ module pad_control
         input  logic             i2s_slave_sck_oe     ,
 
         // SPI MASTER
-        input  logic             spi_master0_csn0_i   ,
-        input  logic             spi_master0_csn1_i   ,
-        input  logic             spi_master0_sck_i    ,
-        output logic             spi_master0_sdi0_o   ,
-        output logic             spi_master0_sdi1_o   ,
-        output logic             spi_master0_sdi2_o   ,
-        output logic             spi_master0_sdi3_o   ,
-        input  logic             spi_master0_sdo0_i   ,
-        input  logic             spi_master0_sdo1_i   ,
-        input  logic             spi_master0_sdo2_i   ,
-        input  logic             spi_master0_sdo3_i   ,
-        input  logic             spi_master0_oen0_i   ,
-        input  logic             spi_master0_oen1_i   ,
-        input  logic             spi_master0_oen2_i   ,
-        input  logic             spi_master0_oen3_i   ,
+        input  logic [N_SPI-1:0]      spi_clk_i,
+        input  logic [N_SPI-1:0][3:0] spi_csn_i,
+        input  logic [N_SPI-1:0][3:0] spi_oen_i,
+        input  logic [N_SPI-1:0][3:0] spi_sdo_i,
+        output logic [N_SPI-1:0][3:0] spi_sdi_o,
 
         // CAMERA INTERFACE
         output logic             cam_pclk_o           ,
@@ -206,6 +191,12 @@ module pad_control
     );
 
    logic s_alt0,s_alt1,s_alt2,s_alt3;
+
+   // check invariants
+   if (N_SPI  <  1 || N_SPI  >  2) $error("The current verion of Pad control supports only 1 or 2 SPI peripherals");
+   if (N_I2C  != 2) $error("The current version of Pad control only supports exactly 2 I2C peripherals");
+   if (N_UART != 1) $error("The current version of Pad control only supports exactly 1 UART peripherals");
+
    // DEFINE DEFAULT FOR NOT USED ALTERNATIVES
    assign s_alt0 = 1'b0;
    assign s_alt1 = 1'b0;
@@ -215,15 +206,15 @@ module pad_control
    /////////////////////////////////////////////////////////////////////////////////////////////
    // OUTPUT ENABLE
    /////////////////////////////////////////////////////////////////////////////////////////////
-   assign oe_spim_sdio0_o  = (pad_mux_i[0 ] == 2'b00) ? ~spi_master0_oen0_i : ((pad_mux_i[0 ] == 2'b01) ? gpio_dir_i[0 ] : ((pad_mux_i[0 ] == 2'b10) ? s_alt2        : s_alt3 ));
-   assign oe_spim_sdio1_o  = (pad_mux_i[1 ] == 2'b00) ? ~spi_master0_oen1_i : ((pad_mux_i[1 ] == 2'b01) ? gpio_dir_i[1 ] : ((pad_mux_i[1 ] == 2'b10) ? s_alt2        : s_alt3 ));
-   assign oe_spim_sdio2_o  = (pad_mux_i[2 ] == 2'b00) ? ~spi_master0_oen2_i : ((pad_mux_i[2 ] == 2'b01) ? gpio_dir_i[2 ] : ((pad_mux_i[2 ] == 2'b10) ? i2c1_sda_oe_i : s_alt3 ));
-   assign oe_spim_sdio3_o  = (pad_mux_i[3 ] == 2'b00) ? ~spi_master0_oen3_i : ((pad_mux_i[3 ] == 2'b01) ? gpio_dir_i[3 ] : ((pad_mux_i[3 ] == 2'b10) ? i2c1_scl_oe_i : s_alt3 ));
+   assign oe_spim_sdio0_o  = (pad_mux_i[0 ] == 2'b00) ? ~spi_oen_i[0][0]    : ((pad_mux_i[0 ] == 2'b01) ? gpio_dir_i[0 ] : ((pad_mux_i[0 ] == 2'b10) ? s_alt2        : s_alt3 ));
+   assign oe_spim_sdio1_o  = (pad_mux_i[1 ] == 2'b00) ? ~spi_oen_i[0][1]    : ((pad_mux_i[1 ] == 2'b01) ? gpio_dir_i[1 ] : ((pad_mux_i[1 ] == 2'b10) ? s_alt2        : s_alt3 ));
+   assign oe_spim_sdio2_o  = (pad_mux_i[2 ] == 2'b00) ? ~spi_oen_i[0][2]    : ((pad_mux_i[2 ] == 2'b01) ? gpio_dir_i[2 ] : ((pad_mux_i[2 ] == 2'b10) ? i2c_sda_oe_i[1] : s_alt3 ));
+   assign oe_spim_sdio3_o  = (pad_mux_i[3 ] == 2'b00) ? ~spi_oen_i[0][3]    : ((pad_mux_i[3 ] == 2'b01) ? gpio_dir_i[3 ] : ((pad_mux_i[3 ] == 2'b10) ? i2c_scl_oe_i[1] : s_alt3 ));
    assign oe_spim_csn0_o   = (pad_mux_i[4 ] == 2'b00) ? 1'b1                : ((pad_mux_i[4 ] == 2'b01) ? gpio_dir_i[4 ] : ((pad_mux_i[4 ] == 2'b10) ? s_alt2        : s_alt3 ));
    assign oe_spim_csn1_o   = (pad_mux_i[5 ] == 2'b00) ? 1'b1                : ((pad_mux_i[5 ] == 2'b01) ? gpio_dir_i[5 ] : ((pad_mux_i[5 ] == 2'b10) ? s_alt2        : s_alt3 ));
    assign oe_spim_sck_o    = (pad_mux_i[6 ] == 2'b00) ? 1'b1                : ((pad_mux_i[6 ] == 2'b01) ? gpio_dir_i[6 ] : ((pad_mux_i[6 ] == 2'b10) ? s_alt2        : s_alt3 ));
-   assign oe_uart_rx_o     = (pad_mux_i[7 ] == 2'b00) ? 1'b0                : ((pad_mux_i[7 ] == 2'b01) ? gpio_dir_i[7 ] : ((pad_mux_i[7 ] == 2'b10) ? i2c1_sda_oe_i : s_alt3 ));
-   assign oe_uart_tx_o     = (pad_mux_i[8 ] == 2'b00) ? 1'b1                : ((pad_mux_i[8 ] == 2'b01) ? gpio_dir_i[8 ] : ((pad_mux_i[8 ] == 2'b10) ? i2c1_scl_oe_i : s_alt3 ));
+   assign oe_uart_rx_o     = (pad_mux_i[7 ] == 2'b00) ? 1'b0                : ((pad_mux_i[7 ] == 2'b01) ? gpio_dir_i[7 ] : ((pad_mux_i[7 ] == 2'b10) ? i2c_sda_oe_i[1] : s_alt3 ));
+   assign oe_uart_tx_o     = (pad_mux_i[8 ] == 2'b00) ? 1'b1                : ((pad_mux_i[8 ] == 2'b01) ? gpio_dir_i[8 ] : ((pad_mux_i[8 ] == 2'b10) ? i2c_scl_oe_i[1] : s_alt3 ));
    assign oe_cam_pclk_o    = (pad_mux_i[9 ] == 2'b00) ? 1'b0                : ((pad_mux_i[9 ] == 2'b01) ? gpio_dir_i[9 ] : ((pad_mux_i[9 ] == 2'b10) ? 1'b1          : s_alt3 ));
    assign oe_cam_hsync_o   = (pad_mux_i[10] == 2'b00) ? 1'b0                : ((pad_mux_i[10] == 2'b01) ? gpio_dir_i[10] : ((pad_mux_i[10] == 2'b10) ? 1'b1          : s_alt3 ));
    assign oe_cam_data0_o   = (pad_mux_i[11] == 2'b00) ? 1'b0                : ((pad_mux_i[11] == 2'b01) ? gpio_dir_i[11] : ((pad_mux_i[11] == 2'b10) ? 1'b1          : s_alt3 ));
@@ -239,10 +230,10 @@ module pad_control
    assign oe_sdio_cmd_o    = (pad_mux_i[21] == 2'b00) ? ~sdio_cmd_oen_i     : ((pad_mux_i[21] == 2'b01) ? gpio_dir_i[21] : ((pad_mux_i[21] == 2'b10) ? 1'b0          : s_alt3 ));
    assign oe_sdio_data0_o  = (pad_mux_i[22] == 2'b00) ? ~sdio_data_oen_i[0] : ((pad_mux_i[22] == 2'b01) ? gpio_dir_i[22] : ((pad_mux_i[22] == 2'b10) ? 1'b0          : s_alt3 ));
    assign oe_sdio_data1_o  = (pad_mux_i[23] == 2'b00) ? ~sdio_data_oen_i[1] : ((pad_mux_i[23] == 2'b01) ? gpio_dir_i[23] : ((pad_mux_i[23] == 2'b10) ? 1'b0          : s_alt3 ));
-   assign oe_sdio_data2_o  = (pad_mux_i[24] == 2'b00) ? ~sdio_data_oen_i[2] : ((pad_mux_i[24] == 2'b01) ? gpio_dir_i[24] : ((pad_mux_i[24] == 2'b10) ? i2c1_sda_oe_i : s_alt3 ));
-   assign oe_sdio_data3_o  = (pad_mux_i[25] == 2'b00) ? ~sdio_data_oen_i[3] : ((pad_mux_i[25] == 2'b01) ? gpio_dir_i[25] : ((pad_mux_i[25] == 2'b10) ? i2c1_scl_oe_i : s_alt3 ));
-   assign oe_i2c0_sda_o    = (pad_mux_i[33] == 2'b00) ? i2c0_sda_oe_i       : ((pad_mux_i[33] == 2'b01) ? gpio_dir_i[26] : ((pad_mux_i[33] == 2'b10) ? s_alt2        : s_alt3 ));
-   assign oe_i2c0_scl_o    = (pad_mux_i[34] == 2'b00) ? i2c0_scl_oe_i       : ((pad_mux_i[34] == 2'b01) ? gpio_dir_i[27] : ((pad_mux_i[34] == 2'b10) ? s_alt2        : s_alt3 ));
+   assign oe_sdio_data2_o  = (pad_mux_i[24] == 2'b00) ? ~sdio_data_oen_i[2] : ((pad_mux_i[24] == 2'b01) ? gpio_dir_i[24] : ((pad_mux_i[24] == 2'b10) ? i2c_sda_oe_i[1] : s_alt3 ));
+   assign oe_sdio_data3_o  = (pad_mux_i[25] == 2'b00) ? ~sdio_data_oen_i[3] : ((pad_mux_i[25] == 2'b01) ? gpio_dir_i[25] : ((pad_mux_i[25] == 2'b10) ? i2c_scl_oe_i[1] : s_alt3 ));
+   assign oe_i2c0_sda_o    = (pad_mux_i[33] == 2'b00) ? i2c_sda_oe_i[0]     : ((pad_mux_i[33] == 2'b01) ? gpio_dir_i[26] : ((pad_mux_i[33] == 2'b10) ? s_alt2        : s_alt3 ));
+   assign oe_i2c0_scl_o    = (pad_mux_i[34] == 2'b00) ? i2c_scl_oe_i[0]     : ((pad_mux_i[34] == 2'b01) ? gpio_dir_i[27] : ((pad_mux_i[34] == 2'b10) ? s_alt2        : s_alt3 ));
    assign oe_i2s0_sck_o    = (pad_mux_i[35] == 2'b00) ? i2s_slave_sck_oe    : ((pad_mux_i[35] == 2'b01) ? gpio_dir_i[28] : ((pad_mux_i[35] == 2'b10) ? s_alt2        : s_alt3 ));
    assign oe_i2s0_ws_o     = (pad_mux_i[36] == 2'b00) ? i2s_slave_ws_oe     : ((pad_mux_i[36] == 2'b01) ? gpio_dir_i[29] : ((pad_mux_i[36] == 2'b10) ? s_alt2        : s_alt3 ));
    assign oe_i2s0_sdi_o    = (pad_mux_i[37] == 2'b00) ? 1'b0                : ((pad_mux_i[37] == 2'b01) ? gpio_dir_i[30] : ((pad_mux_i[37] == 2'b10) ? s_alt2        : s_alt3 ));
@@ -251,15 +242,15 @@ module pad_control
    /////////////////////////////////////////////////////////////////////////////////////////////
    // DATA OUTPUT
    /////////////////////////////////////////////////////////////////////////////////////////////
-   assign out_spim_sdio0_o = (pad_mux_i[0 ] == 2'b00) ? spi_master0_sdo0_i : ((pad_mux_i[0 ] == 2'b01) ? gpio_out_i[0 ] : ((pad_mux_i[0 ] == 2'b10) ? s_alt2         : s_alt3 ));
-   assign out_spim_sdio1_o = (pad_mux_i[1 ] == 2'b00) ? spi_master0_sdo1_i : ((pad_mux_i[1 ] == 2'b01) ? gpio_out_i[1 ] : ((pad_mux_i[1 ] == 2'b10) ? s_alt2         : s_alt3 ));
-   assign out_spim_sdio2_o = (pad_mux_i[2 ] == 2'b00) ? spi_master0_sdo2_i : ((pad_mux_i[2 ] == 2'b01) ? gpio_out_i[2 ] : ((pad_mux_i[2 ] == 2'b10) ? i2c1_sda_out_i : s_alt3 ));
-   assign out_spim_sdio3_o = (pad_mux_i[3 ] == 2'b00) ? spi_master0_sdo3_i : ((pad_mux_i[3 ] == 2'b01) ? gpio_out_i[3 ] : ((pad_mux_i[3 ] == 2'b10) ? i2c1_scl_out_i : s_alt3 ));
-   assign out_spim_csn0_o  = (pad_mux_i[4 ] == 2'b00) ? spi_master0_csn0_i : ((pad_mux_i[4 ] == 2'b01) ? gpio_out_i[4 ] : ((pad_mux_i[4 ] == 2'b10) ? s_alt2         : s_alt3 ));
-   assign out_spim_csn1_o  = (pad_mux_i[5 ] == 2'b00) ? spi_master0_csn1_i : ((pad_mux_i[5 ] == 2'b01) ? gpio_out_i[5 ] : ((pad_mux_i[5 ] == 2'b10) ? s_alt2         : s_alt3 ));
-   assign out_spim_sck_o   = (pad_mux_i[6 ] == 2'b00) ? spi_master0_sck_i  : ((pad_mux_i[6 ] == 2'b01) ? gpio_out_i[6 ] : ((pad_mux_i[6 ] == 2'b10) ? s_alt2         : s_alt3 ));
-   assign out_uart_rx_o    = (pad_mux_i[7 ] == 2'b00) ? 1'b0               : ((pad_mux_i[7 ] == 2'b01) ? gpio_out_i[7 ] : ((pad_mux_i[7 ] == 2'b10) ? i2c1_sda_out_i : s_alt3 ));
-   assign out_uart_tx_o    = (pad_mux_i[8 ] == 2'b00) ? uart_tx_i          : ((pad_mux_i[8 ] == 2'b01) ? gpio_out_i[8 ] : ((pad_mux_i[8 ] == 2'b10) ? i2c1_scl_out_i : s_alt3 ));
+   assign out_spim_sdio0_o = (pad_mux_i[0 ] == 2'b00) ? spi_sdo_i[0][0]    : ((pad_mux_i[0 ] == 2'b01) ? gpio_out_i[0 ] : ((pad_mux_i[0 ] == 2'b10) ? s_alt2         : s_alt3 ));
+   assign out_spim_sdio1_o = (pad_mux_i[1 ] == 2'b00) ? spi_sdo_i[0][1]    : ((pad_mux_i[1 ] == 2'b01) ? gpio_out_i[1 ] : ((pad_mux_i[1 ] == 2'b10) ? s_alt2         : s_alt3 ));
+   assign out_spim_sdio2_o = (pad_mux_i[2 ] == 2'b00) ? spi_sdo_i[0][2]    : ((pad_mux_i[2 ] == 2'b01) ? gpio_out_i[2 ] : ((pad_mux_i[2 ] == 2'b10) ? i2c_sda_out_i[1] : s_alt3 ));
+   assign out_spim_sdio3_o = (pad_mux_i[3 ] == 2'b00) ? spi_sdo_i[0][3]    : ((pad_mux_i[3 ] == 2'b01) ? gpio_out_i[3 ] : ((pad_mux_i[3 ] == 2'b10) ? i2c_scl_out_i[1] : s_alt3 ));
+   assign out_spim_csn0_o  = (pad_mux_i[4 ] == 2'b00) ? spi_csn_i[0][0]    : ((pad_mux_i[4 ] == 2'b01) ? gpio_out_i[4 ] : ((pad_mux_i[4 ] == 2'b10) ? s_alt2         : s_alt3 ));
+   assign out_spim_csn1_o  = (pad_mux_i[5 ] == 2'b00) ? spi_csn_i[0][1]    : ((pad_mux_i[5 ] == 2'b01) ? gpio_out_i[5 ] : ((pad_mux_i[5 ] == 2'b10) ? s_alt2         : s_alt3 ));
+   assign out_spim_sck_o   = (pad_mux_i[6 ] == 2'b00) ? spi_clk_i[0]       : ((pad_mux_i[6 ] == 2'b01) ? gpio_out_i[6 ] : ((pad_mux_i[6 ] == 2'b10) ? s_alt2         : s_alt3 ));
+   assign out_uart_rx_o    = (pad_mux_i[7 ] == 2'b00) ? 1'b0               : ((pad_mux_i[7 ] == 2'b01) ? gpio_out_i[7 ] : ((pad_mux_i[7 ] == 2'b10) ? i2c_sda_out_i[1] : s_alt3 ));
+   assign out_uart_tx_o    = (pad_mux_i[8 ] == 2'b00) ? uart_tx_i          : ((pad_mux_i[8 ] == 2'b01) ? gpio_out_i[8 ] : ((pad_mux_i[8 ] == 2'b10) ? i2c_scl_out_i[1] : s_alt3 ));
    assign out_cam_pclk_o   = (pad_mux_i[9 ] == 2'b00) ? 1'b0               : ((pad_mux_i[9 ] == 2'b01) ? gpio_out_i[9 ] : ((pad_mux_i[9 ] == 2'b10) ? timer1_i[0]    : s_alt3 ));
    assign out_cam_hsync_o  = (pad_mux_i[10] == 2'b00) ? 1'b0               : ((pad_mux_i[10] == 2'b01) ? gpio_out_i[10] : ((pad_mux_i[10] == 2'b10) ? timer1_i[1]    : s_alt3 ));
    assign out_cam_data0_o  = (pad_mux_i[11] == 2'b00) ? 1'b0               : ((pad_mux_i[11] == 2'b01) ? gpio_out_i[11] : ((pad_mux_i[11] == 2'b10) ? timer1_i[2]    : s_alt3 ));
@@ -275,10 +266,10 @@ module pad_control
    assign out_sdio_cmd_o   = (pad_mux_i[21] == 2'b00) ? sdio_cmd_i         : ((pad_mux_i[21] == 2'b01) ? gpio_out_i[21] : ((pad_mux_i[21] == 2'b10) ? s_alt2         : s_alt3 ));
    assign out_sdio_data0_o = (pad_mux_i[22] == 2'b00) ? sdio_data_i[0]     : ((pad_mux_i[22] == 2'b01) ? gpio_out_i[22] : ((pad_mux_i[22] == 2'b10) ? s_alt2         : s_alt3 ));
    assign out_sdio_data1_o = (pad_mux_i[23] == 2'b00) ? sdio_data_i[1]     : ((pad_mux_i[23] == 2'b01) ? gpio_out_i[23] : ((pad_mux_i[23] == 2'b10) ? s_alt2         : s_alt3 ));
-   assign out_sdio_data2_o = (pad_mux_i[24] == 2'b00) ? sdio_data_i[2]     : ((pad_mux_i[24] == 2'b01) ? gpio_out_i[24] : ((pad_mux_i[24] == 2'b10) ? i2c1_sda_out_i : s_alt3 ));
-   assign out_sdio_data3_o = (pad_mux_i[25] == 2'b00) ? sdio_data_i[3]     : ((pad_mux_i[25] == 2'b01) ? gpio_out_i[25] : ((pad_mux_i[25] == 2'b10) ? i2c1_scl_out_i : s_alt3 ));
-   assign out_i2c0_sda_o   = (pad_mux_i[33] == 2'b00) ? i2c0_sda_out_i     : ((pad_mux_i[33] == 2'b01) ? gpio_out_i[26] : ((pad_mux_i[33] == 2'b10) ? s_alt2         : s_alt3 ));
-   assign out_i2c0_scl_o   = (pad_mux_i[34] == 2'b00) ? i2c0_scl_out_i     : ((pad_mux_i[34] == 2'b01) ? gpio_out_i[27] : ((pad_mux_i[34] == 2'b10) ? s_alt2         : s_alt3 ));
+   assign out_sdio_data2_o = (pad_mux_i[24] == 2'b00) ? sdio_data_i[2]     : ((pad_mux_i[24] == 2'b01) ? gpio_out_i[24] : ((pad_mux_i[24] == 2'b10) ? i2c_sda_out_i[1] : s_alt3 ));
+   assign out_sdio_data3_o = (pad_mux_i[25] == 2'b00) ? sdio_data_i[3]     : ((pad_mux_i[25] == 2'b01) ? gpio_out_i[25] : ((pad_mux_i[25] == 2'b10) ? i2c_scl_out_i[1] : s_alt3 ));
+   assign out_i2c0_sda_o   = (pad_mux_i[33] == 2'b00) ? i2c_sda_out_i[0]   : ((pad_mux_i[33] == 2'b01) ? gpio_out_i[26] : ((pad_mux_i[33] == 2'b10) ? s_alt2         : s_alt3 ));
+   assign out_i2c0_scl_o   = (pad_mux_i[34] == 2'b00) ? i2c_scl_out_i[0]   : ((pad_mux_i[34] == 2'b01) ? gpio_out_i[27] : ((pad_mux_i[34] == 2'b10) ? s_alt2         : s_alt3 ));
    assign out_i2s0_sck_o   = (pad_mux_i[35] == 2'b00) ? i2s_slave_sck_i    : ((pad_mux_i[35] == 2'b01) ? gpio_out_i[28] : ((pad_mux_i[35] == 2'b10) ? s_alt2         : s_alt3 ));
    assign out_i2s0_ws_o    = (pad_mux_i[36] == 2'b00) ? i2s_slave_ws_i     : ((pad_mux_i[36] == 2'b01) ? gpio_out_i[29] : ((pad_mux_i[36] == 2'b10) ? s_alt2         : s_alt3 ));
    assign out_i2s0_sdi_o   = (pad_mux_i[37] == 2'b00) ? 1'b0               : ((pad_mux_i[37] == 2'b01) ? gpio_out_i[30] : ((pad_mux_i[37] == 2'b10) ? s_alt2         : s_alt3 ));
@@ -289,7 +280,7 @@ module pad_control
    /////////////////////////////////////////////////////////////////////////////////////////////
    //    SPI MASTER1
    // assign spi_master1_sdi_o = (pad_mux_i[0]  == 2'b00) ? in_rf_miso_i: (pad_mux_i[40] == 2'b00) ? in_spim1_miso_i : 1'b0;
-   assign spi_master1_sdi_o = 1'b0;
+   // assign spi_sdi_o[1] = 1'b0;
 
    assign sdio_cmd_o     = (pad_mux_i[21] == 2'b00) ? in_sdio_cmd_i   : 1'b0;
    assign sdio_data_o[0] = (pad_mux_i[22] == 2'b00) ? in_sdio_data0_i : 1'b0;
@@ -311,22 +302,23 @@ module pad_control
    assign cam_vsync_o   = (pad_mux_i[19] == 2'b00) ? in_cam_vsync_i : 1'b0;
 
    //    I2C1
-   assign i2c1_sda_in_o = (pad_mux_i[2] == 2'b10) ? in_spim_sdio2_i : (pad_mux_i[7] == 2'b10) ? in_uart_rx_i : (pad_mux_i[24] == 2'b10) ? in_sdio_data2_i: 1'b1 ;
-   assign i2c1_scl_in_o = (pad_mux_i[3] == 2'b10) ? in_spim_sdio3_i : (pad_mux_i[8] == 2'b10) ? in_uart_tx_i : (pad_mux_i[25] == 2'b10) ? in_sdio_data3_i: 1'b1 ;
+   assign i2c_sda_in_o[1] = (pad_mux_i[2] == 2'b10) ? in_spim_sdio2_i : (pad_mux_i[7] == 2'b10) ? in_uart_rx_i : (pad_mux_i[24] == 2'b10) ? in_sdio_data2_i: 1'b1 ;
+   assign i2c_scl_in_o[1] = (pad_mux_i[3] == 2'b10) ? in_spim_sdio3_i : (pad_mux_i[8] == 2'b10) ? in_uart_tx_i : (pad_mux_i[25] == 2'b10) ? in_sdio_data3_i: 1'b1 ;
 
    assign i2s_slave_sd1_o  = (pad_mux_i[29] == 2'b00) ? in_i2s1_sdi_i : (pad_mux_i[27] == 2'b11) ? in_i2s1_sdi_i : 1'b0;
 
    //    UART
    assign uart_rx_o     = (pad_mux_i[38] == 2'b00) ? in_uart_rx_i : 1'b1;
 
-   assign spi_master0_sdi0_o = (pad_mux_i[33] == 2'b00) ? in_spim_sdio0_i : 1'b0;
-   assign spi_master0_sdi1_o = (pad_mux_i[34] == 2'b00) ? in_spim_sdio1_i : 1'b0;
-   assign spi_master0_sdi2_o = (pad_mux_i[35] == 2'b00) ? in_spim_sdio2_i : 1'b0;
-   assign spi_master0_sdi3_o = (pad_mux_i[36] == 2'b00) ? in_spim_sdio3_i : 1'b0;
+   //    SPI
+   assign spi_sdi_o[0][0] = (pad_mux_i[33] == 2'b00) ? in_spim_sdio0_i : 1'b0;
+   assign spi_sdi_o[0][1] = (pad_mux_i[34] == 2'b00) ? in_spim_sdio1_i : 1'b0;
+   assign spi_sdi_o[0][2] = (pad_mux_i[35] == 2'b00) ? in_spim_sdio2_i : 1'b0;
+   assign spi_sdi_o[0][3] = (pad_mux_i[36] == 2'b00) ? in_spim_sdio3_i : 1'b0;
 
    //    I2C0
-   assign i2c0_sda_in_o      = (pad_mux_i[43] == 2'b00) ? in_i2c0_sda_i : 1'b1;
-   assign i2c0_scl_in_o      = (pad_mux_i[44] == 2'b00) ? in_i2c0_scl_i : 1'b1;
+   assign i2c_sda_in_o[0]      = (pad_mux_i[43] == 2'b00) ? in_i2c0_sda_i : 1'b1;
+   assign i2c_scl_in_o[0]      = (pad_mux_i[44] == 2'b00) ? in_i2c0_scl_i : 1'b1;
 
 
    assign i2s_slave_sck_o       = (pad_mux_i[45] == 2'b00) ? in_i2s0_sck_i : 1'b0;

--- a/rtl/pulp/pulp.sv
+++ b/rtl/pulp/pulp.sv
@@ -856,6 +856,10 @@ module pulp
 
         .bootsel_i                    ( s_bootsel                        ),
 
+        // we immediately start booting in the default setup
+        .fc_fetch_en_valid_i          ( 1'b1                             ),
+        .fc_fetch_en_i                ( 1'b1                             ),
+
         .jtag_tck_i                   ( s_jtag_tck                       ),
         .jtag_trst_ni                 ( s_jtag_trst                      ),
         .jtag_tms_i                   ( s_jtag_tms                       ),

--- a/rtl/pulp/pulp.sv
+++ b/rtl/pulp/pulp.sv
@@ -837,7 +837,7 @@ module pulp
       .AXI_STRB_OUT_WIDTH ( AXI_SOC_CLUSTER_STRB_WIDTH ),
       .BUFFER_WIDTH       ( BUFFER_WIDTH               ),
       .EVNT_WIDTH         ( EVENT_WIDTH                ),
-      .NB_CL_CORES        ( 0                          ),
+      .NB_CL_CORES        ( `NB_CORES                  ),
       .N_UART             ( N_UART                     ),
       .N_SPI              ( N_SPI                      ),
       .N_I2C              ( N_I2C                      )

--- a/rtl/pulp/pulp.sv
+++ b/rtl/pulp/pulp.sv
@@ -329,6 +329,25 @@ module pulp
   logic [127:0]                s_pad_mux_soc;
   logic [383:0]                s_pad_cfg_soc;
 
+  // due to the pad frame these numbers are fixed. Adjust the padframe
+  // accordingly if you change these.
+  localparam int unsigned N_UART = 1;
+  localparam int unsigned N_SPI = 1;
+  localparam int unsigned N_I2C = 2;
+
+  logic [N_SPI-1:0]            s_spi_clk;
+  logic [N_SPI-1:0][3:0]       s_spi_csn;
+  logic [N_SPI-1:0][3:0]       s_spi_oen;
+  logic [N_SPI-1:0][3:0]       s_spi_sdo;
+  logic [N_SPI-1:0][3:0]       s_spi_sdi;
+
+  logic [N_I2C-1:0]            s_i2c_scl_in;
+  logic [N_I2C-1:0]            s_i2c_scl_out;
+  logic [N_I2C-1:0]            s_i2c_scl_oe;
+  logic [N_I2C-1:0]            s_i2c_sda_in;
+  logic [N_I2C-1:0]            s_i2c_sda_out;
+  logic [N_I2C-1:0]            s_i2c_sda_oe;
+
   //***********************************************************
   //********** SOC TO CLUSTER DOMAINS SIGNALS *****************
   //***********************************************************
@@ -651,19 +670,12 @@ module pulp
         .uart_tx_i                  ( s_uart_tx                   ),
         .uart_rx_o                  ( s_uart_rx                   ),
 
-        .i2c0_scl_out_i             ( s_i2c0_scl_out              ),
-        .i2c0_scl_in_o              ( s_i2c0_scl_in               ),
-        .i2c0_scl_oe_i              ( s_i2c0_scl_oe               ),
-        .i2c0_sda_out_i             ( s_i2c0_sda_out              ),
-        .i2c0_sda_in_o              ( s_i2c0_sda_in               ),
-        .i2c0_sda_oe_i              ( s_i2c0_sda_oe               ),
-
-        .i2c1_scl_out_i             ( s_i2c1_scl_out              ),
-        .i2c1_scl_in_o              ( s_i2c1_scl_in               ),
-        .i2c1_scl_oe_i              ( s_i2c1_scl_oe               ),
-        .i2c1_sda_out_i             ( s_i2c1_sda_out              ),
-        .i2c1_sda_in_o              ( s_i2c1_sda_in               ),
-        .i2c1_sda_oe_i              ( s_i2c1_sda_oe               ),
+        .i2c_scl_out_i              ( s_i2c_scl_out               ),
+        .i2c_scl_in_o               ( s_i2c_scl_in                ),
+        .i2c_scl_oe_i               ( s_i2c_scl_oe                ),
+        .i2c_sda_out_i              ( s_i2c_sda_out               ),
+        .i2c_sda_in_o               ( s_i2c_sda_in                ),
+        .i2c_sda_oe_i               ( s_i2c_sda_oe                ),
 
         .i2s_slave_sd0_o            ( s_i2s_sd0_in                ),
         .i2s_slave_sd1_o            ( s_i2s_sd1_in                ),
@@ -674,28 +686,11 @@ module pulp
         .i2s_slave_sck_i            ( s_i2s_sck0_out              ),
         .i2s_slave_sck_oe           ( s_i2s_slave_sck_oe          ),
 
-        .spi_master0_csn0_i         ( s_spi_master0_csn0          ),
-        .spi_master0_csn1_i         ( s_spi_master0_csn1          ),
-        .spi_master0_sck_i          ( s_spi_master0_sck           ),
-        .spi_master0_sdi0_o         ( s_spi_master0_sdi0          ),
-        .spi_master0_sdi1_o         ( s_spi_master0_sdi1          ),
-        .spi_master0_sdi2_o         ( s_spi_master0_sdi2          ),
-        .spi_master0_sdi3_o         ( s_spi_master0_sdi3          ),
-        .spi_master0_sdo0_i         ( s_spi_master0_sdo0          ),
-        .spi_master0_sdo1_i         ( s_spi_master0_sdo1          ),
-        .spi_master0_sdo2_i         ( s_spi_master0_sdo2          ),
-        .spi_master0_sdo3_i         ( s_spi_master0_sdo3          ),
-        .spi_master0_oen0_i         ( s_spi_master0_oen0          ),
-        .spi_master0_oen1_i         ( s_spi_master0_oen1          ),
-        .spi_master0_oen2_i         ( s_spi_master0_oen2          ),
-        .spi_master0_oen3_i         ( s_spi_master0_oen3          ),
-
-        .spi_master1_csn0_i         ( 1'b1                        ),
-        .spi_master1_csn1_i         ( 1'b1                        ),
-        .spi_master1_sck_i          ( 1'b0                        ),
-        .spi_master1_sdi_o          (                             ),
-        .spi_master1_sdo_i          ( 1'b0                        ),
-        .spi_master1_mode_i         ( 2'b00                       ),
+        .spi_clk_i                  ( s_spi_clk                   ),
+        .spi_csn_i                  ( s_spi_csn                   ),
+        .spi_oen_i                  ( s_spi_oen                   ),
+        .spi_sdo_i                  ( s_spi_sdo                   ),
+        .spi_sdi_o                  ( s_spi_sdi                   ),
 
         .sdio_clk_i                 ( s_sdio_clk                  ),
         .sdio_cmd_i                 ( s_sdio_cmdo                 ),
@@ -841,7 +836,11 @@ module pulp
       .AXI_STRB_IN_WIDTH  ( AXI_CLUSTER_SOC_STRB_WIDTH ),
       .AXI_STRB_OUT_WIDTH ( AXI_SOC_CLUSTER_STRB_WIDTH ),
       .BUFFER_WIDTH       ( BUFFER_WIDTH               ),
-      .EVNT_WIDTH         ( EVENT_WIDTH                )
+      .EVNT_WIDTH         ( EVENT_WIDTH                ),
+      .NB_CL_CORES        ( 0                          ),
+      .N_UART             ( N_UART                     ),
+      .N_SPI              ( N_SPI                      ),
+      .N_I2C              ( N_I2C                      )
    ) soc_domain_i (
 
         .ref_clk_i                    ( s_ref_clk                        ),
@@ -887,19 +886,12 @@ module pulp
         .timer_ch2_o                  ( s_timer2                         ),
         .timer_ch3_o                  ( s_timer3                         ),
 
-        .i2c0_scl_i                   ( s_i2c0_scl_in                    ),
-        .i2c0_scl_o                   ( s_i2c0_scl_out                   ),
-        .i2c0_scl_oe_o                ( s_i2c0_scl_oe                    ),
-        .i2c0_sda_i                   ( s_i2c0_sda_in                    ),
-        .i2c0_sda_o                   ( s_i2c0_sda_out                   ),
-        .i2c0_sda_oe_o                ( s_i2c0_sda_oe                    ),
-
-        .i2c1_scl_i                   ( s_i2c1_scl_in                    ),
-        .i2c1_scl_o                   ( s_i2c1_scl_out                   ),
-        .i2c1_scl_oe_o                ( s_i2c1_scl_oe                    ),
-        .i2c1_sda_i                   ( s_i2c1_sda_in                    ),
-        .i2c1_sda_o                   ( s_i2c1_sda_out                   ),
-        .i2c1_sda_oe_o                ( s_i2c1_sda_oe                    ),
+        .i2c_scl_i                    ( s_i2c_scl_in                     ),
+        .i2c_scl_o                    ( s_i2c_scl_out                    ),
+        .i2c_scl_oe_o                 ( s_i2c_scl_oe                     ),
+        .i2c_sda_i                    ( s_i2c_sda_in                     ),
+        .i2c_sda_o                    ( s_i2c_sda_out                    ),
+        .i2c_sda_oe_o                 ( s_i2c_sda_oe                     ),
 
         .i2s_slave_sd0_i              ( s_i2s_sd0_in                     ),
         .i2s_slave_sd1_i              ( s_i2s_sd1_in                     ),
@@ -910,21 +902,11 @@ module pulp
         .i2s_slave_sck_o              ( s_i2s_sck0_out                   ),
         .i2s_slave_sck_oe             ( s_i2s_slave_sck_oe               ),
 
-        .spi_master0_clk_o            ( s_spi_master0_sck                ),
-        .spi_master0_csn0_o           ( s_spi_master0_csn0               ),
-        .spi_master0_csn1_o           ( s_spi_master0_csn1               ),
-        .spi_master0_oen0_o           ( s_spi_master0_oen0               ),
-        .spi_master0_oen1_o           ( s_spi_master0_oen1               ),
-        .spi_master0_oen2_o           ( s_spi_master0_oen2               ),
-        .spi_master0_oen3_o           ( s_spi_master0_oen3               ),
-        .spi_master0_sdo0_o           ( s_spi_master0_sdo0               ),
-        .spi_master0_sdo1_o           ( s_spi_master0_sdo1               ),
-        .spi_master0_sdo2_o           ( s_spi_master0_sdo2               ),
-        .spi_master0_sdo3_o           ( s_spi_master0_sdo3               ),
-        .spi_master0_sdi0_i           ( s_spi_master0_sdi0               ),
-        .spi_master0_sdi1_i           ( s_spi_master0_sdi1               ),
-        .spi_master0_sdi2_i           ( s_spi_master0_sdi2               ),
-        .spi_master0_sdi3_i           ( s_spi_master0_sdi3               ),
+        .spi_clk_o                    ( s_spi_clk                        ),
+        .spi_csn_o                    ( s_spi_csn                        ),
+        .spi_oen_o                    ( s_spi_oen                        ),
+        .spi_sdo_o                    ( s_spi_sdo                        ),
+        .spi_sdi_i                    ( s_spi_sdi                        ),
 
         .sdio_clk_o                   ( s_sdio_clk                       ),
         .sdio_cmd_o                   ( s_sdio_cmdo                      ),

--- a/rtl/pulp/safe_domain.sv
+++ b/rtl/pulp/safe_domain.sv
@@ -12,7 +12,10 @@
 module safe_domain
     #(
         parameter FLL_DATA_WIDTH = 32,
-        parameter FLL_ADDR_WIDTH = 32
+        parameter FLL_ADDR_WIDTH = 32,
+        parameter int unsigned N_UART = 1,
+        parameter int unsigned N_SPI = 1,
+        parameter int unsigned N_I2C = 2
     )
     (
         input  logic             ref_clk_i            ,
@@ -45,21 +48,13 @@ module safe_domain
         input  logic             uart_tx_i            ,
         output logic             uart_rx_o            ,
 
-        // I2C0
-        input  logic             i2c0_scl_out_i       ,
-        output logic             i2c0_scl_in_o        ,
-        input  logic             i2c0_scl_oe_i        ,
-        input  logic             i2c0_sda_out_i       ,
-        output logic             i2c0_sda_in_o        ,
-        input  logic             i2c0_sda_oe_i        ,
-
-        // I2C1
-        input  logic             i2c1_scl_out_i       ,
-        output logic             i2c1_scl_in_o        ,
-        input  logic             i2c1_scl_oe_i        ,
-        input  logic             i2c1_sda_out_i       ,
-        output logic             i2c1_sda_in_o        ,
-        input  logic             i2c1_sda_oe_i        ,
+        // I2C
+        input  logic [N_I2C-1:0] i2c_scl_out_i,
+        output logic [N_I2C-1:0] i2c_scl_in_o,
+        input  logic [N_I2C-1:0] i2c_scl_oe_i,
+        input  logic [N_I2C-1:0] i2c_sda_out_i,
+        output logic [N_I2C-1:0] i2c_sda_in_o,
+        input  logic [N_I2C-1:0] i2c_sda_oe_i,
 
         // I2S
         output logic             i2s_slave_sd0_o      ,
@@ -72,30 +67,13 @@ module safe_domain
         input  logic             i2s_slave_sck_oe     ,
 
         // SPI MASTER
-        input  logic             spi_master0_csn0_i   ,
-        input  logic             spi_master0_csn1_i   ,
-        input  logic             spi_master0_sck_i    ,
-        output logic             spi_master0_sdi0_o   ,
-        output logic             spi_master0_sdi1_o   ,
-        output logic             spi_master0_sdi2_o   ,
-        output logic             spi_master0_sdi3_o   ,
-        input  logic             spi_master0_sdo0_i   ,
-        input  logic             spi_master0_sdo1_i   ,
-        input  logic             spi_master0_sdo2_i   ,
-        input  logic             spi_master0_sdo3_i   ,
-        input  logic             spi_master0_oen0_i   ,
-        input  logic             spi_master0_oen1_i   ,
-        input  logic             spi_master0_oen2_i   ,
-        input  logic             spi_master0_oen3_i   ,
+        input  logic [N_SPI-1:0]      spi_clk_i,
+        input  logic [N_SPI-1:0][3:0] spi_csn_i,
+        input  logic [N_SPI-1:0][3:0] spi_oen_i,
+        input  logic [N_SPI-1:0][3:0] spi_sdo_i,
+        output logic [N_SPI-1:0][3:0] spi_sdi_o,
 
-        input  logic             spi_master1_csn0_i   ,
-        input  logic             spi_master1_csn1_i   ,
-        input  logic             spi_master1_sck_i    ,
-        output logic             spi_master1_sdi_o    ,
-        input  logic             spi_master1_sdo_i    ,
-        input  logic [1:0]       spi_master1_mode_i,
-
-
+        // SDIO
         input  logic             sdio_clk_i,
         input  logic             sdio_cmd_i,
         output logic             sdio_cmd_o,
@@ -258,19 +236,12 @@ module safe_domain
         .uart_tx_i             ( uart_tx_i             ),
         .uart_rx_o             ( uart_rx_o             ),
 
-        .i2c0_scl_out_i        ( i2c0_scl_out_i        ),
-        .i2c0_scl_in_o         ( i2c0_scl_in_o         ),
-        .i2c0_scl_oe_i         ( i2c0_scl_oe_i         ),
-        .i2c0_sda_out_i        ( i2c0_sda_out_i        ),
-        .i2c0_sda_in_o         ( i2c0_sda_in_o         ),
-        .i2c0_sda_oe_i         ( i2c0_sda_oe_i         ),
-
-        .i2c1_scl_out_i        ( i2c1_scl_out_i        ),
-        .i2c1_scl_in_o         ( i2c1_scl_in_o         ),
-        .i2c1_scl_oe_i         ( i2c1_scl_oe_i         ),
-        .i2c1_sda_out_i        ( i2c1_sda_out_i        ),
-        .i2c1_sda_in_o         ( i2c1_sda_in_o         ),
-        .i2c1_sda_oe_i         ( i2c1_sda_oe_i         ),
+        .i2c_scl_out_i         ( i2c_scl_out_i         ),
+        .i2c_scl_in_o          ( i2c_scl_in_o          ),
+        .i2c_scl_oe_i          ( i2c_scl_oe_i          ),
+        .i2c_sda_out_i         ( i2c_sda_out_i         ),
+        .i2c_sda_in_o          ( i2c_sda_in_o          ),
+        .i2c_sda_oe_i          ( i2c_sda_oe_i          ),
 
         .i2s_slave_sd0_o       ( i2s_slave_sd0_o       ),
         .i2s_slave_sd1_o       ( i2s_slave_sd1_o       ),
@@ -281,21 +252,11 @@ module safe_domain
         .i2s_slave_sck_i       ( i2s_slave_sck_i       ),
         .i2s_slave_sck_oe      ( i2s_slave_sck_oe      ),
 
-        .spi_master0_csn0_i    ( spi_master0_csn0_i    ),
-        .spi_master0_csn1_i    ( spi_master0_csn1_i    ),
-        .spi_master0_sck_i     ( spi_master0_sck_i     ),
-        .spi_master0_sdi0_o    ( spi_master0_sdi0_o    ),
-        .spi_master0_sdi1_o    ( spi_master0_sdi1_o    ),
-        .spi_master0_sdi2_o    ( spi_master0_sdi2_o    ),
-        .spi_master0_sdi3_o    ( spi_master0_sdi3_o    ),
-        .spi_master0_sdo0_i    ( spi_master0_sdo0_i    ),
-        .spi_master0_sdo1_i    ( spi_master0_sdo1_i    ),
-        .spi_master0_sdo2_i    ( spi_master0_sdo2_i    ),
-        .spi_master0_sdo3_i    ( spi_master0_sdo3_i    ),
-        .spi_master0_oen0_i    ( spi_master0_oen0_i    ),
-        .spi_master0_oen1_i    ( spi_master0_oen1_i    ),
-        .spi_master0_oen2_i    ( spi_master0_oen2_i    ),
-        .spi_master0_oen3_i    ( spi_master0_oen3_i    ),
+        .spi_clk_i             ( spi_clk_i             ),
+        .spi_csn_i             ( spi_csn_i             ),
+        .spi_oen_i             ( spi_oen_i             ),
+        .spi_sdo_i             ( spi_sdo_i             ),
+        .spi_sdi_o             ( spi_sdi_o             ),
 
         .sdio_clk_i            ( sdio_clk_i            ),
         .sdio_cmd_i            ( sdio_cmd_i            ),

--- a/rtl/pulp/soc_domain.sv
+++ b/rtl/pulp/soc_domain.sv
@@ -24,8 +24,13 @@ module soc_domain #(
     parameter AXI_USER_WIDTH       = 6,
     parameter AXI_STRB_IN_WIDTH    = AXI_DATA_IN_WIDTH/8,
     parameter AXI_STRB_OUT_WIDTH   = AXI_DATA_OUT_WIDTH/8,
+
     parameter BUFFER_WIDTH         = 8,
-    parameter EVNT_WIDTH           = 8
+    parameter EVNT_WIDTH           = 8,
+
+    parameter int unsigned N_UART  = 1,
+    parameter int unsigned N_SPI   = 1,
+    parameter int unsigned N_I2C   = 2
 )(
 
     input logic                              ref_clk_i,
@@ -73,19 +78,12 @@ module soc_domain #(
     output logic [3:0]                       timer_ch2_o,
     output logic [3:0]                       timer_ch3_o,
 
-    input  logic                             i2c0_scl_i,
-    output logic                             i2c0_scl_o,
-    output logic                             i2c0_scl_oe_o,
-    input  logic                             i2c0_sda_i,
-    output logic                             i2c0_sda_o,
-    output logic                             i2c0_sda_oe_o,
-
-    input  logic                             i2c1_scl_i,
-    output logic                             i2c1_scl_o,
-    output logic                             i2c1_scl_oe_o,
-    input  logic                             i2c1_sda_i,
-    output logic                             i2c1_sda_o,
-    output logic                             i2c1_sda_oe_o,
+    input  logic [N_I2C-1:0]                 i2c_scl_i,
+    output logic [N_I2C-1:0]                 i2c_scl_o,
+    output logic [N_I2C-1:0]                 i2c_scl_oe_o,
+    input  logic [N_I2C-1:0]                 i2c_sda_i,
+    output logic [N_I2C-1:0]                 i2c_sda_o,
+    output logic [N_I2C-1:0]                 i2c_sda_oe_o,
 
     input  logic                             i2s_slave_sd0_i,
     input  logic                             i2s_slave_sd1_i,
@@ -96,21 +94,11 @@ module soc_domain #(
     output logic                             i2s_slave_sck_o,
     output logic                             i2s_slave_sck_oe,
 
-    output logic                             spi_master0_clk_o,
-    output logic                             spi_master0_csn0_o,
-    output logic                             spi_master0_csn1_o,
-    output logic                             spi_master0_oen0_o,
-    output logic                             spi_master0_oen1_o,
-    output logic                             spi_master0_oen2_o,
-    output logic                             spi_master0_oen3_o,
-    output logic                             spi_master0_sdo0_o,
-    output logic                             spi_master0_sdo1_o,
-    output logic                             spi_master0_sdo2_o,
-    output logic                             spi_master0_sdo3_o,
-    input  logic                             spi_master0_sdi0_i,
-    input  logic                             spi_master0_sdi1_i,
-    input  logic                             spi_master0_sdi2_i,
-    input  logic                             spi_master0_sdi3_i,
+    output logic [N_SPI-1:0]                 spi_clk_o,
+    output logic [N_SPI-1:0][3:0]            spi_csn_o,
+    output logic [N_SPI-1:0][3:0]            spi_oen_o,
+    output logic [N_SPI-1:0][3:0]            spi_sdo_o,
+    input  logic [N_SPI-1:0][3:0]            spi_sdi_i,
 
     output logic                             sdio_clk_o,
     output logic                             sdio_cmd_o,
@@ -262,7 +250,14 @@ module soc_domain #(
         .AXI_ID_OUT_WIDTH        ( AXI_ID_OUT_WIDTH   ),
         .AXI_USER_WIDTH          ( AXI_USER_WIDTH     ),
         .EVNT_WIDTH              ( EVNT_WIDTH         ),
-        .BUFFER_WIDTH            ( BUFFER_WIDTH       )
+        .BUFFER_WIDTH            ( BUFFER_WIDTH       ),
+        .NGPIO                   ( 43                 ),
+        .NPAD                    ( 64                 ),
+        .NBIT_PADCFG             ( 4                  ),
+        .NBIT_PADMUX             ( 2                  ),
+        .N_UART                  ( N_UART             ),
+        .N_SPI                   ( N_SPI              ),
+        .N_I2C                   ( N_I2C              )
    )
    pulp_soc_i
    (

--- a/rtl/pulp/soc_domain.sv
+++ b/rtl/pulp/soc_domain.sv
@@ -237,8 +237,7 @@ module soc_domain #(
     output logic [7:0]                       data_master_b_readpointer_o
     );
 
-    pulp_soc
-    #(
+    pulp_soc #(
         .CORE_TYPE               ( CORE_TYPE          ),
         .USE_FPU                 ( USE_FPU            ),
         .USE_HWPE                ( USE_HWPE           ),
@@ -258,9 +257,7 @@ module soc_domain #(
         .N_UART                  ( N_UART             ),
         .N_SPI                   ( N_SPI              ),
         .N_I2C                   ( N_I2C              )
-   )
-   pulp_soc_i
-   (
+   ) pulp_soc_i (
 
         .boot_l2_i                    ( 1'b0                         ),
         .cluster_dbg_irq_valid_o      ( dbg_irq_valid_o     ),    //dbg_irq_valid_o

--- a/rtl/pulp/soc_domain.sv
+++ b/rtl/pulp/soc_domain.sv
@@ -41,6 +41,9 @@ module soc_domain #(
 
     input logic                              bootsel_i,
 
+    input  logic                             fc_fetch_en_valid_i,
+    input  logic                             fc_fetch_en_i,
+
     input  logic                             jtag_tck_i,
     input  logic                             jtag_trst_ni,
     input  logic                             jtag_tms_i,


### PR DESCRIPTION
Updates to SPI and I2C connected to pulp_soc based on changes in pulpissimo: https://github.com/pulp-platform/pulpissimo/commit/c35bc1574fa5b6011b86b7c292c60c1df6d82082