### PR TITLE
Ibex cluster integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /sim/ncompile/*
 !/sim/ncompile/build.mk
 /tests/*/
+/pulp-runtime/*
+/regression_tests/*

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,6 @@ checkout:
 
 # generic clean and build targets for the platform
 clean:
-	rm -rf $(VSIM_PATH)
 	cd sim && $(MAKE) clean
 
 build:
@@ -106,7 +105,7 @@ test-local-regressions:
 	cp -r regression_tests/riscv_tests/* regression_tests/riscv_tests_soc
 	source setup/vsim.sh; \
 	source pulp-runtime/configs/pulp.sh; \
-	cd regression_tests && ../pulp-runtime/scripts/bwruntests.py --proc-verbose -v --report-junit -t 600 --yaml -o simplified-runtime.xml regression-tests.yaml
+	cd regression_tests && ../pulp-runtime/scripts/bwruntests.py --proc-verbose -v --report-junit -t 1800 --yaml -o simplified-runtime.xml regression-tests.yaml
 
 git-ci-ml-regs:
 	source setup/vsim.sh; \

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -24,9 +24,9 @@ pulp_soc:
   group:  pulp-platform
 
 pulp_cluster:
-  commit: ibex_integration
+  commit: d124108e8688f89baa56dd9247b3b198ddb0f3b3
   server: https://github.com
-  group:  micprog
+  group:  pulp-platform
 
 tbtools:
   commit: v0.1

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -24,9 +24,9 @@ pulp_soc:
   group:  pulp-platform
 
 pulp_cluster:
-  commit: pulp_cluster_v1.2
+  commit: ibex_integration
   server: https://github.com
-  group:  pulp-platform
+  group:  micprog
 
 tbtools:
   commit: v0.1

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -24,7 +24,7 @@ pulp_soc:
   group:  pulp-platform
 
 pulp_cluster:
-  commit: d124108e8688f89baa56dd9247b3b198ddb0f3b3
+  commit: 69bca050eef7087fd4cd26fb8babfa21f9c5d38a
   server: https://github.com
   group:  pulp-platform
 

--- a/rtl/includes/pulp_soc_defines.sv
+++ b/rtl/includes/pulp_soc_defines.sv
@@ -23,9 +23,9 @@
 `define FC_ALIAS
 
 // To use new icache use this define
-// `define MP_ICACHE
+`define MP_ICACHE
 // `define SP_ICACHE
-`define PRIVATE_ICACHE
+// `define PRIVATE_ICACHE
 
 // To use The L2 Multibank Feature, please decomment this define
 `define USE_L2_MULTIBANK
@@ -62,7 +62,7 @@
 `define FEATURE_ICACHE_STAT
 
 
-`define HIERARCHY_ICACHE_32BIT 
+// `define HIERARCHY_ICACHE_32BIT 
 
 
 `ifdef PULP_FPGA_EMUL

--- a/rtl/includes/pulp_soc_defines.sv
+++ b/rtl/includes/pulp_soc_defines.sv
@@ -23,9 +23,9 @@
 `define FC_ALIAS
 
 // To use new icache use this define
-`define MP_ICACHE
-//`define SP_ICACHE
-//`define PRIVATE_ICACHE
+// `define MP_ICACHE
+// `define SP_ICACHE
+`define PRIVATE_ICACHE
 
 // To use The L2 Multibank Feature, please decomment this define
 `define USE_L2_MULTIBANK
@@ -62,6 +62,7 @@
 `define FEATURE_ICACHE_STAT
 
 
+`define HIERARCHY_ICACHE_32BIT 
 
 
 `ifdef PULP_FPGA_EMUL

--- a/rtl/pulp/cluster_domain.sv
+++ b/rtl/pulp/cluster_domain.sv
@@ -299,8 +299,7 @@ module cluster_domain
         .CLUSTER_ALIAS_BASE           ( CLUSTER_ALIAS_BASE           )
     )
 `endif    
-    cluster_i
-    (
+    cluster_i (
         .clk_i                        ( clk_i                        ),
         .rst_ni                       ( rst_ni                       ),
         .ref_clk_i                    ( ref_clk_i                    ),

--- a/rtl/pulp/cluster_domain.sv
+++ b/rtl/pulp/cluster_domain.sv
@@ -40,14 +40,18 @@ module cluster_domain
     parameter SET_ASSOCIATIVE       = 4,
 `ifdef MP_ICACHE
     parameter NB_CACHE_BANKS        = 2,
-`endif
+`else
 
 `ifdef SP_ICACHE
     parameter NB_CACHE_BANKS        = 8,
-`endif
+`else
 
 `ifdef PRIVATE_ICACHE
-    parameter NB_CACHE_BANKS        = 8,
+    parameter NB_CACHE_BANKS        = `NB_CORES,
+`else 
+    parameter NB_CACHE_BANKS        = 0,
+`endif
+`endif
 `endif
 
     parameter CACHE_LINE            = 1,

--- a/rtl/pulp/cluster_domain.sv
+++ b/rtl/pulp/cluster_domain.sv
@@ -25,6 +25,7 @@
 module cluster_domain
 #(
     //CLUSTER PARAMETERS
+    parameter CORE_TYPE_CL          = 0, // 0 for RISCY, 1 for IBEX RV32IMC (formerly ZERORISCY), 2 for IBEX RV32EC (formerly MICRORISCY)
     parameter NB_CORES              = `NB_CORES,
     parameter NB_HWPE_PORTS         = 4,
     parameter NB_DMAS               = 4,
@@ -252,6 +253,7 @@ module cluster_domain
     pulp_cluster
 `ifndef USE_CLUSTER_NETLIST
     #(
+        .CORE_TYPE_CL                 ( CORE_TYPE_CL                 ),
         .NB_CORES                     ( NB_CORES                     ),
         .NB_HWPE_PORTS                ( NB_HWPE_PORTS                ),
         .NB_DMAS                      ( NB_DMAS                      ),

--- a/rtl/pulp/pulp.sv
+++ b/rtl/pulp/pulp.sv
@@ -12,9 +12,10 @@
 
 module pulp
 #(
-  parameter CORE_TYPE   = 0, // 0 for RISCY, 1 for IBEX RV32IMC (formerly ZERORISCY), 2 for IBEX RV32EC (formerly MICRORISCY)
-  parameter USE_FPU     = 1,
-  parameter USE_HWPE    = 1
+  parameter CORE_TYPE_FC   = 0, // 0 for RISCY, 1 for IBEX RV32IMC (formerly ZERORISCY), 2 for IBEX RV32EC (formerly MICRORISCY)
+  parameter CORE_TYPE_CL   = 0, // 0 for RISCY, 1 for IBEX RV32IMC (formerly ZERORISCY), 2 for IBEX RV32EC (formerly MICRORISCY)
+  parameter USE_FPU        = 1,
+  parameter USE_HWPE       = 1
 )
 (
 
@@ -824,7 +825,7 @@ module pulp
 
    // SOC DOMAIN
    soc_domain #(
-      .CORE_TYPE          ( CORE_TYPE                  ),
+      .CORE_TYPE          ( CORE_TYPE_FC               ),
       .USE_FPU            ( USE_FPU                    ),
       .USE_HWPE           ( USE_HWPE                   ),
       .AXI_ADDR_WIDTH     ( AXI_ADDR_WIDTH             ),
@@ -1044,8 +1045,9 @@ module pulp
         .*
     );
 
-cluster_domain cluster_domain_i
-    (
+cluster_domain #(
+    .CORE_TYPE_CL           ( CORE_TYPE_CL )
+  ) cluster_domain_i (
         .clk_i                        ( s_cluster_clk                    ),
         .rst_ni                       ( s_cluster_rstn                   ),
         .ref_clk_i                    ( s_ref_clk                        ),

--- a/rtl/tb/tb_pulp.sv
+++ b/rtl/tb/tb_pulp.sv
@@ -31,13 +31,16 @@ module tb_pulp;
 
    /* simulation platform parameters */
 
-   // Choose your core: 0 for RISCY, 1 for ZERORISCY
+   // Choose your Fabric Controller core: 
+   // 0 for RISCY, 1 for IBEX RV32IMC (formerly ZERORISCY), 2 for IBEX RV32EC (formerly MICRORISCY)
    parameter CORE_TYPE_FC         = 0;
    // if RISCY is instantiated (CORE_TYPE == 0), RISCY_FPU enables the FPU
    parameter RISCY_FPU            = 1;
 
    parameter USE_HWPE             = 0;
 
+   // Choose your Cluster core: 
+   // 0 for RISCY, 1 for IBEX RV32IMC (formerly ZERORISCY), 2 for IBEX RV32EC (formerly MICRORISCY)
    parameter CORE_TYPE_CL         = 0;
 
    // the following parameters can activate instantiation of the verification IPs for SPI, I2C and I2s

--- a/rtl/tb/tb_pulp.sv
+++ b/rtl/tb/tb_pulp.sv
@@ -32,9 +32,13 @@ module tb_pulp;
    /* simulation platform parameters */
 
    // Choose your core: 0 for RISCY, 1 for ZERORISCY
-   parameter CORE_TYPE            = 0;
+   parameter CORE_TYPE_FC         = 0;
    // if RISCY is instantiated (CORE_TYPE == 0), RISCY_FPU enables the FPU
    parameter RISCY_FPU            = 1;
+
+   parameter USE_HWPE             = 0;
+
+   parameter CORE_TYPE_CL         = 0;
 
    // the following parameters can activate instantiation of the verification IPs for SPI, I2C and I2s
    // see the instructions in rtl/vip/{i2c_eeprom,i2s,spi_flash} to download the verification IPs
@@ -535,8 +539,10 @@ module tb_pulp;
 
    // PULP chip (design under test)
    pulp #(
-      .CORE_TYPE ( CORE_TYPE ),
-      .USE_FPU   ( RISCY_FPU )
+      .CORE_TYPE_FC ( CORE_TYPE_FC ),
+      .CORE_TYPE_CL ( CORE_TYPE_CL ),
+      .USE_FPU      ( RISCY_FPU    ),
+      .USE_HWPE     ( USE_HWPE     )
    )
    i_dut (
       .pad_spim_sdio0     ( w_spi_master_sdio0 ),


### PR DESCRIPTION
Add configurable option for ibex as cluster core. This should not affect use with the riscv core. Ibex is not yet fully tested as the SDK is not yet compatible, but work is in progress. See https://github.com/pulp-platform/pulp_cluster/pull/20 for other changes.