### PR TITLE
Update SoC/cluster versions to include HCI, fix NB_HWPE_PORTS to 9

### DIFF
--- a/ips_list.yml
+++ b/ips_list.yml
@@ -19,12 +19,12 @@
 #
 
 pulp_soc:
-  commit: v1.4.2
+  commit: v1.4.3
   server: https://github.com
   group:  pulp-platform
 
 pulp_cluster:
-  commit: pulp_cluster_v1.2
+  commit: v1.4
   server: https://github.com
   group:  pulp-platform
 

--- a/rtl/pulp/cluster_domain.sv
+++ b/rtl/pulp/cluster_domain.sv
@@ -26,7 +26,7 @@ module cluster_domain
 #(
     //CLUSTER PARAMETERS
     parameter NB_CORES              = `NB_CORES,
-    parameter NB_HWPE_PORTS         = 4,
+    parameter NB_HWPE_PORTS         = 9,
     parameter NB_DMAS               = 4,
 
     parameter TCDM_SIZE             = 64*1024,                 // in Byte, POWER of 2


### PR DESCRIPTION
- SoC changes are limited to HWPE versions, which have to be aligned with whatever is used inside cluster
- cluster now includes heterogeneous interconnect (optionally, can be controlled with a parameter) and dummy data-mover HWPE (also optionally)

Regression tests on the cluster passed, checked in https://github.com/pulp-platform/pulp_cluster/pull/24