### PR TITLE
[TB] poll debug module's SBCS register and clear errors in status reg check

### DIFF
--- a/rtl/tb/jtag_pkg.sv
+++ b/rtl/tb/jtag_pkg.sv
@@ -901,6 +901,30 @@ package jtag_pkg;
 
       endtask
 
+
+      task clear_sbcserrors(
+                            ref logic s_tck,
+                            ref logic s_tms,
+                            ref logic s_trstn,
+                            ref logic s_tdi,
+                            ref logic s_tdo
+                            );
+
+         // writing to the error flags has "clear bit" behavior:
+         // if they are 1 and we write a 0, they will stay 1
+         // all other status/write combinations will leave them cleared, so reading SBCS
+         // and writing the same value back will always clear the error flags
+         dm::sbcs_t sbcs;
+
+         this.read_debug_reg(dm::SBCS, sbcs,
+                             s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+
+         if (sbcs.sbbusyerror || (|sbcs.sberror)) begin
+           this.write_debug_reg(dm::SBCS, sbcs,
+                                s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+         end
+      endtask
+
       task test_read_abstractcs(
          ref logic s_tck,
          ref logic s_tms,

--- a/rtl/tb/tb_pulp.sv
+++ b/rtl/tb/tb_pulp.sv
@@ -945,6 +945,12 @@ module tb_pulp;
 
             jtag_data[0] = 0;
             while(jtag_data[0][31] == 0) begin
+               // every 10th loop iteration, clear the debug module's SBA unit CSR to make
+               // sure there's no error blocking our reads. Sometimes a TCDM read
+               // request issued by the debug module takes longer than it takes
+               // for the read request to the debug module to arrive and it
+               // stores an error in the SBCS register. By clearing it
+               // periodically we make sure the test can terminate.
                if (rd_cnt % 10 == 0) begin
                   debug_mode_if.clear_sbcserrors(s_tck, s_tms, s_trstn, s_tdi, s_tdo);
                end

--- a/rtl/tb/tb_pulp.sv
+++ b/rtl/tb/tb_pulp.sv
@@ -729,6 +729,7 @@ module tb_pulp;
          logic [6:0]  dm_addr;
          logic        error;
          int         num_err;
+         int         rd_cnt;
          automatic logic [9:0]  FC_CORE_ID = {5'd31, 5'd0};
 
          int entry_point;
@@ -736,6 +737,7 @@ module tb_pulp;
 
          error   = 1'b0;
          num_err = 0;
+         rd_cnt = 0;
 
          // read entry point from commandline
          if ($value$plusargs("ENTRY_POINT=%h", entry_point))
@@ -943,8 +945,11 @@ module tb_pulp;
 
             jtag_data[0] = 0;
             while(jtag_data[0][31] == 0) begin
+               if (rd_cnt % 10 == 0) begin
+                  debug_mode_if.clear_sbcserrors(s_tck, s_tms, s_trstn, s_tdi, s_tdo);
+               end
                debug_mode_if.readMem(32'h1A1040A0, jtag_data[0], s_tck, s_tms, s_trstn, s_tdi, s_tdo);
-
+               rd_cnt++;
                #50us;
             end
 


### PR DESCRIPTION
This fixes a potential bug:
TCDM reads issued by the debug module may take so long to get filled that the JTAG request to read out the result of the memory read comes too early. In this case, the debug module sets an internal error flag which prevents it from issuing any more TCDM transactions. By periodically clearing this error flag in the testbench while checking the core status register, we make sure that tests terminate correctly.