### PR TITLE
Fixed linkage in remote_bitbang library

### DIFF
--- a/rtl/tb/remote_bitbang/remote_bitbang.c
+++ b/rtl/tb/remote_bitbang/remote_bitbang.c
@@ -13,6 +13,22 @@
 
 #include "remote_bitbang.h"
 
+int rbs_err;
+
+unsigned char tck;
+unsigned char tms;
+unsigned char tdi;
+unsigned char trstn;
+unsigned char tdo;
+unsigned char quit;
+
+int socket_fd;
+int client_fd;
+
+const ssize_t buf_size = 64 * 1024;
+char recv_buf[64 * 1024];
+ssize_t recv_start, recv_end;
+
 int rbs_init(uint16_t port)
 {
     socket_fd  = 0;

--- a/rtl/tb/remote_bitbang/remote_bitbang.h
+++ b/rtl/tb/remote_bitbang/remote_bitbang.h
@@ -8,21 +8,21 @@
 
 #define VERBOSE 0
 
-int rbs_err;
+extern int rbs_err;
 
-unsigned char tck;
-unsigned char tms;
-unsigned char tdi;
-unsigned char trstn;
-unsigned char tdo;
-unsigned char quit;
+extern unsigned char tck;
+extern unsigned char tms;
+extern unsigned char tdi;
+extern unsigned char trstn;
+extern unsigned char tdo;
+extern unsigned char quit;
 
-int socket_fd;
-int client_fd;
+extern int socket_fd;
+extern int client_fd;
 
-static const ssize_t buf_size = 64 * 1024;
-char recv_buf[64 * 1024];
-ssize_t recv_start, recv_end;
+extern const ssize_t buf_size;
+extern char recv_buf[];
+extern ssize_t recv_start, recv_end;
 
 // Create a new server, listening for connections from localhost on the given
 // port.


### PR DESCRIPTION
This is the same patch applied as in pulp-platform/pulpissimo#264.