### PR TITLE
Bump PULP cluster to fix cluster alias

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -14,7 +14,7 @@ dependencies:
   tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.6 }
   jtag_pulp:          { git: "https://github.com/pulp-platform/jtag_pulp.git", version: 0.1.0 }
   pulp_soc:           { git: "https://github.com/pulp-platform/pulp_soc.git", version: ~3.0.0 }
-  pulp_cluster:       { git: "https://github.com/pulp-platform/pulp_cluster.git", rev: "040fc3e3b2dbf11ce0d08bf7554f310c483b8c9f" }
+  pulp_cluster:       { git: "https://github.com/pulp-platform/pulp_cluster.git", rev: "db2e173b8b7562092fb9d922d64e0a7bd21da411" }
   tbtools:            { git: "https://github.com/pulp-platform/tbtools.git", version: 0.2.1 }
 
 export_include_dirs:


### PR DESCRIPTION
Pointing to the most recent commit of PULP cluster to include the correct initialization and definition of `cluster_alias`. This fixes post synthesis simulations.